### PR TITLE
Switch default values for int64 from OpenAPI framework to plain code

### DIFF
--- a/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
+++ b/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
@@ -93,6 +93,15 @@ public class DsStorageApiServiceImpl implements DsStorageApi {
 
     @Override
     public StreamingOutput getRecordsModifiedAfter(String recordBase, Long mTime, Long maxRecords) {
+        // Both mTime and maxRecords defaults should be set in the OpenAPI YAML, but the current version of
+        // the OpenAPI generator does not support defaults for longs (int64)
+        if (mTime == null) {
+            mTime = 0L;
+        }
+        if (maxRecords == null) {
+            maxRecords = 1000L;
+        }
+        
         try {
             log.info("getRecordsModifiedAfter called with parameters recordBase:{} mTime:{} maxRecords:{} batchSize:{}",
                      recordBase, mTime, maxRecords, ServiceConfig.getDBBatchSize());

--- a/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
+++ b/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
@@ -95,19 +95,15 @@ public class DsStorageApiServiceImpl implements DsStorageApi {
     public StreamingOutput getRecordsModifiedAfter(String recordBase, Long mTime, Long maxRecords) {
         // Both mTime and maxRecords defaults should be set in the OpenAPI YAML, but the current version of
         // the OpenAPI generator does not support defaults for longs (int64)
-        if (mTime == null) {
-            mTime = 0L;
-        }
-        if (maxRecords == null) {
-            maxRecords = 1000L;
-        }
-        
+        long finalMTime = mTime == null ? 0L : mTime;
+        long finalMaxRecords = maxRecords == null ? 1000L : maxRecords;
+
         try {
             log.info("getRecordsModifiedAfter called with parameters recordBase:{} mTime:{} maxRecords:{} batchSize:{}",
-                     recordBase, mTime, maxRecords, ServiceConfig.getDBBatchSize());
+                     recordBase, finalMTime, finalMaxRecords, ServiceConfig.getDBBatchSize());
 
-            String filename = "records_" + mTime + ".json";
-            if (maxRecords <= 2) { // The Swagger GUI is extremely sluggish for inline rendering
+            String filename = "records_" + finalMTime + ".json";
+            if (finalMaxRecords <= 2) { // The Swagger GUI is extremely sluggish for inline rendering
                 // A few records is ok to show inline in the Swagger GUI:
                 // Show inline in Swagger UI, inline when opened directly in browser
                 httpServletResponse.setHeader("Content-Disposition", "inline; filename=\"" + filename + "\"");
@@ -121,7 +117,7 @@ public class DsStorageApiServiceImpl implements DsStorageApi {
             return output -> {
                 try (ExportWriter writer = ExportWriterFactory.wrap(
                         output, httpServletResponse, ExportWriterFactory.FORMAT.json, false, "records")) {
-                    DsStorageFacade.getRecordsModifiedAfter(writer, recordBase, mTime, maxRecords, ServiceConfig.getDBBatchSize());
+                    DsStorageFacade.getRecordsModifiedAfter(writer, recordBase, finalMTime, finalMaxRecords, ServiceConfig.getDBBatchSize());
                 }
             };
         } catch (Exception e){

--- a/src/main/openapi/openapi_ds-storage_v1.yaml
+++ b/src/main/openapi/openapi_ds-storage_v1.yaml
@@ -153,7 +153,8 @@ paths:
             type: integer
             format: int64  
             example: 0
-            default: 0
+            # Default values for longs does not work with the current version of OpenAPI generator
+            #default: 0
         - name: maxRecords
           in: query
           description: 'Maximum number of records to return. -1 means no limit'
@@ -162,7 +163,8 @@ paths:
             type: integer
             format: int64
             example: 1000
-            default: 1000
+            # Default values for longs does not work with the current version of OpenAPI generator
+            #default: 1000
 
       responses:
         '200':


### PR DESCRIPTION
Temporary "solution" until the OpenAPI generator has been upgraded