### PR TITLE
Change jetty port to 9072 instead of default 8080 to avoid collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.2.0] - 2022-02-XX
 ### Added
 API service methods renamed (url's).
-    
-#### ID normalisation                     
+
+### Changed
+ID normalisation:
 If a record contains a invalid character after the recordbase part, it will be normalised and the invalid characters will be replaced.
 The original (invalid) id will be stored in the 'orgid' field and flagged for invalid id. Having the original id will make it possible
 to track it back to the collection it came from. The record can still be retrieved and updated using the invalid id, but also by the normalised id.
 Regexp for recordbase: ([a-z0-9.]+)       
 Regexp for id: ([a-z0-9.]+):([a-zA-Z0-9:._-]+)
-    
+
+Jetty port set explicitly to 9072 instead of default 8080 to avoid collisions with projects using default tomcat/jetty setup.
 
 
 ## [1.1.0] - 2022-02-01

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -32,7 +32,7 @@ uses a PostGreSQL server that must be installed and have the database tables cre
 ```
 
 
-The Swagger UI is available at <http://localhost:8080/ds-storage/api/>, providing access to the `v1` version of the GUI. 
+The Swagger UI is available at <http://localhost:9072/ds-storage/api/>, providing access to the `v1` version of the GUI. 
 
 ## java webapp template structure
 
@@ -55,7 +55,7 @@ repositories. To guard against this, `conf/ds-storage-environment.yaml` is added
 
 Jetty is a servlet container (like Tomcat) that is often used for testing during development.
 
-This project can be started with `mvn jetty:run`, which will expose a webserver with the implemented service at port 8080.
+This project can be started with `mvn jetty:run`, which will expose a webserver with the implemented service at port 9072.
 If it is started in debug mode from an IDE (normally IntelliJ IDEA), breakpoints and all the usual debug functionality
 will be available.
 
@@ -88,7 +88,7 @@ and also uploaded to nexus as part of the release procedure. The tar-ball contai
 
 For smaller projects or standalone web applications, it can be useful to bundle the user interface with the API 
 implementation: Files and folders added to the `src/main/webapp/` folder are served under 
-[http://localhost:8080/<application-ID>/](http://localhost:8080/<application-ID>/).
+[http://localhost:9072/<application-ID>/](http://localhost:9072/<application-ID>/).
 
 While it is possible to use [JSP](https://en.wikipedia.org/wiki/Jakarta_Server_Pages), as the sample 
 [index.jsp](./src/main/webapp/index.jsp) shows, this is considered legacy technology.
@@ -157,7 +157,7 @@ should
     `*ServiceImpl` import)
   * Add a new `servlet` and a new `servlet-mapping` for the new `Application` in `src/main/webapp/WEB-INF/web.xml`  
   * Add the path to the new OpenAPI YAML to `urls` in `webapp/api/index.html`. The first entry in the array is the
-    default when visiting the main API-page at <http://localhost:8080/ds-storage/api/>  
+    default when visiting the main API-page at <http://localhost:9072/ds-storage/api/>  
 
 After a `mvn package`, a skeleton implementation for the new version of the API class will be created in the source
 tree. The standard action is to copy the implementation for the previous version to the new one and adjust from there.  

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The H2 will be created if does not exists and data will be persistent between se
 mvn jetty:run
 ```
 ## Swagger UI
-The Swagger UI is available at <http://localhost:9073/ds-storage/api/>, providing access to both the `v1` and the 
+The Swagger UI is available at <http://localhost:9072/ds-storage/api/>, providing access to both the `v1` and the 
 `devel` versions of the GUI. 
 
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The H2 will be created if does not exists and data will be persistent between se
 mvn jetty:run
 ```
 ## Swagger UI
-The Swagger UI is available at <http://localhost:8080/ds-storage/api/>, providing access to both the `v1` and the 
+The Swagger UI is available at <http://localhost:9073/ds-storage/api/>, providing access to both the `v1` and the 
 `devel` versions of the GUI. 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -557,6 +557,9 @@
                         <descriptor>${project.build.finalName}/WEB-INF/web.xml</descriptor>
                         <jettyEnvXml>${project.basedir}/target/jetty-res/jetty-env.xml</jettyEnvXml>
                     </webApp>
+                    <httpConnector>
+                        <port>9072</port>
+                    </httpConnector>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Both Jetty & Tomcat uses port 8080 per default so chances are high that running `mvn jetty:run` will fail due to some other jetty/tomcat application has already been started. The solution is to use another port for test-runs of ds-storage.