### PR TITLE
Refresh stage 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.4.6</version>
+            <version>1.4.12</version>
             <exclusions>
                 <exclusion>
                     <!-- kb-util has 2.3.3, but transitive resolving has 2.4.0 somewhere-->

--- a/pom.xml
+++ b/pom.xml
@@ -549,12 +549,15 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>10.0.0.alpha1</version>
+                <version>10.0.12</version>
                 <configuration>
                     <useTestScope>true</useTestScope>
+                    <!-- https://www.eclipse.org/jetty/documentation/jetty-10/programming-guide/index.html#jetty-run-goal -->
+                    <!-- https://stackoverflow.com/questions/12493798/jetty-maven-plugin-using-scan -->
+                    <scan>2</scan>
                     <webApp>
                         <contextPath>/${project.artifactId}/</contextPath>
-                        <descriptor>${project.build.finalName}/WEB-INF/web.xml</descriptor>
+                        <descriptor>${project.basedir}/target/${project.build.finalName}/WEB-INF/web.xml</descriptor>
                         <jettyEnvXml>${project.basedir}/target/jetty-res/jetty-env.xml</jettyEnvXml>
                     </webApp>
                     <httpConnector>

--- a/src/main/templates/TEMPLATE_README.md
+++ b/src/main/templates/TEMPLATE_README.md
@@ -1,0 +1,22 @@
+# OpenAPI generator templates
+
+Copied and adapted from https://github.com/OpenAPITools/openapi-generator/
+to provide streaming support.
+
+
+# API and Impl, concrete source unknown, adapted for streaming support
+
+ * `api.mustache`
+ * `apiServiceImpl.mustache`
+ * `returnTypes.mustache`
+
+# Model (DTO), taken from openapi-generator/..Java/ version 4.2.2
+
+This was done to get withXML to add `@JacksonXmlRootElement` and other Jackson annotations
+needed for returning XML with proper element names (`book` instead of `BookDto` etc.).
+
+ * pojo.mustache
+ * model.mustache (adapted with extra imports)
+ * modelInnerEnum.mustache
+ * modelEnum.mustache (adapted with `import io.swagger.annotations.ApiModelProperty;` )
+ * jackson_annotations.mustache

--- a/src/main/templates/api.mustache
+++ b/src/main/templates/api.mustache
@@ -21,6 +21,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiModelProperty;
 import io.swagger.jaxrs.PATCH;
 {{#useBeanValidation}}
 import javax.validation.constraints.*;

--- a/src/main/templates/apiServiceImpl.mustache
+++ b/src/main/templates/apiServiceImpl.mustache
@@ -4,8 +4,8 @@ import {{package}}.*;
 {{#imports}}import {{import}};
 {{/imports}}
 
-import {{packageName}}.webservice.exception.ServiceException;
-import {{packageName}}.webservice.exception.InternalServiceException;
+import dk.kb.util.webservice.exception.ServiceException;
+import dk.kb.util.webservice.exception.InternalServiceException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,6 +14,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 {{#generateOperationBody}}
 import java.io.File;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -23,6 +25,7 @@ import org.openapitools.codegen.utils.JsonCache;
 import org.openapitools.codegen.utils.JsonCache.CacheException;
 {{/loadTestDataFromFile}}
 {{/generateOperationBody}}
+import dk.kb.util.webservice.ImplBase;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
 import javax.servlet.ServletConfig;
@@ -63,7 +66,7 @@ import org.springframework.stereotype.Service;
  *
  */
 {{/appName}}
-public class {{classname}}ServiceImpl implements {{classname}} {
+public class {{classname}}ServiceImpl extends ImplBase implements {{classname}} {
     private Logger log = LoggerFactory.getLogger(this.toString());
 
 {{#generateOperationBody}}
@@ -82,43 +85,6 @@ public class {{classname}}ServiceImpl implements {{classname}} {
 
 {{/loadTestDataFromFile}}
 {{/generateOperationBody}}
-
-
-    /* How to access the various web contexts. See https://cxf.apache.org/docs/jax-rs-basics.html#JAX-RSBasics-Contextannotations */
-
-    @Context
-    private transient UriInfo uriInfo;
-
-    @Context
-    private transient SecurityContext securityContext;
-
-    @Context
-    private transient HttpHeaders httpHeaders;
-
-    @Context
-    private transient Providers providers;
-
-    @Context
-    private transient Request request;
-
-    // Disabled as it is always null? TODO: Investigate when it can be not-null, then re-enable with type
-    //@Context
-    //private transient ContextResolver contextResolver;
-
-    @Context
-    private transient HttpServletRequest httpServletRequest;
-
-    @Context
-    private transient HttpServletResponse httpServletResponse;
-
-    @Context
-    private transient ServletContext servletContext;
-
-    @Context
-    private transient ServletConfig servletConfig;
-
-    @Context
-    private transient MessageContext messageContext;
 
 
 {{#operations}}
@@ -168,18 +134,9 @@ non-void response:
                 }}{{^vendorExtensions.x-java-is-response-void}}{{!
 pre-populated operation body:
                     }}{{#generateOperationBody}}
-        try{ {{#vendorExtensions.x-streamingOutput}}
-            String filename = "somefile";
+        try { {{#vendorExtensions.x-streamingOutput}}
             // Show download link in Swagger UI, inline when opened directly in browser
-            // https://github.com/swagger-api/swagger-ui/issues/3832
-            httpServletResponse.setHeader("Content-Disposition", "inline; swaggerDownload=\"attachment\"; filename=\"" + filename + "\"");
-
-            // Show inline in Swagger UI, inline when opened directly in browser
-            // httpServletResponse.setHeader("Content-Disposition", "inline; filename=\"" + filename + "\"");
-
-            // Show download link in Swagger UI, download dialog when opened directly in browser
-            // httpServletResponse.setHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
-
+            setFilename("somefile", true, false);
             return output -> output.write("Magic".getBytes(java.nio.charset.StandardCharsets.UTF_8));{{!
         }}{{/vendorExtensions.x-streamingOutput}}{{!
         }}{{^vendorExtensions.x-streamingOutput}}
@@ -197,21 +154,6 @@ pre-populated operation body:
     }
 
 {{/operation}}
-
-    /**
-    * This method simply converts any Exception into a Service exception
-    * @param e: Any kind of exception
-    * @return A ServiceException
-    * @see dk.kb.storage.webservice.ServiceExceptionMapper
-    */
-    private ServiceException handleException(Exception e) {
-        if (e instanceof ServiceException) {
-            return (ServiceException) e; // Do nothing - this is a declared ServiceException from within module.
-        } else {// Unforseen exception (should not happen). Wrap in internal service exception
-            log.error("ServiceException(HTTP 500):", e); //You probably want to log this.
-            return new InternalServiceException(e.getMessage());
-        }
-    }
 
 }
 {{/operations}}

--- a/src/main/templates/jackson_annotations.mustache
+++ b/src/main/templates/jackson_annotations.mustache
@@ -1,0 +1,19 @@
+{{!
+ If this is map and items are nullable, make sure that nulls are included.
+ To determine what JsonInclude.Include method to use, consider the following:
+ * If the field is required, always include it, even if it is null.
+ * Else use custom behaviour, IOW use whatever is defined on the object mapper
+ }}
+  @JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}})
+  @JsonInclude({{#isMapContainer}}{{#items.isNullable}}content = JsonInclude.Include.ALWAYS, {{/items.isNullable}}{{/isMapContainer}}value = JsonInclude.Include.{{#required}}ALWAYS{{/required}}{{^required}}USE_DEFAULTS{{/required}})
+  {{#withXml}}
+    {{^isContainer}}
+  @JacksonXmlProperty({{#isXmlAttribute}}isAttribute = true, {{/isXmlAttribute}}{{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+    {{/isContainer}}
+    {{#isContainer}}
+      {{#isXmlWrapped}}
+  // items.xmlName={{items.xmlName}}
+  @JacksonXmlElementWrapper(useWrapping = {{isXmlWrapped}}, {{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#items.xmlName}}{{items.xmlName}}{{/items.xmlName}}{{^items.xmlName}}{{items.baseName}}{{/items.xmlName}}")
+      {{/isXmlWrapped}}
+    {{/isContainer}}
+  {{/withXml}}

--- a/src/main/templates/model.mustache
+++ b/src/main/templates/model.mustache
@@ -1,0 +1,52 @@
+{{>licenseInfo}}
+
+package {{package}};
+
+{{#useReflectionEqualsHashCode}}
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+{{/useReflectionEqualsHashCode}}
+{{^supportJava6}}
+import java.util.Objects;
+import java.util.Arrays;
+{{/supportJava6}}
+{{#supportJava6}}
+import org.apache.commons.lang3.ObjectUtils;
+{{/supportJava6}}
+{{#imports}}
+import {{import}};
+{{/imports}}
+{{#serializableModel}}
+import java.io.Serializable;
+{{/serializableModel}}
+{{#jackson}}
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonCreator;
+{{#withXml}}
+import com.fasterxml.jackson.dataformat.xml.annotation.*;
+{{/withXml}}
+{{/jackson}}
+import io.swagger.annotations.ApiModelProperty;
+{{#withXml}}
+import javax.xml.bind.annotation.*;
+{{/withXml}}
+{{#parcelableModel}}
+import android.os.Parcelable;
+import android.os.Parcel;
+{{/parcelableModel}}
+{{#useBeanValidation}}
+import javax.validation.constraints.*;
+import javax.validation.Valid;
+{{/useBeanValidation}}
+{{#performBeanValidation}}
+import org.hibernate.validator.constraints.*;
+{{/performBeanValidation}}
+
+{{#models}}
+{{#model}}
+{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{^isEnum}}{{>pojo}}{{/isEnum}}
+{{/model}}
+{{/models}}

--- a/src/main/templates/modelEnum.mustache
+++ b/src/main/templates/modelEnum.mustache
@@ -1,0 +1,74 @@
+{{#jackson}}
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+{{/jackson}}
+    import io.swagger.annotations.ApiModelProperty;
+{{#gson}}
+import java.io.IOException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+{{/gson}}
+
+/**
+ * {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{description}}{{/description}}
+ */
+{{#gson}}
+@JsonAdapter({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.Adapter.class)
+{{/gson}}
+public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
+  {{#allowableValues}}{{#enumVars}}
+    {{#enumDescription}}
+  /**
+   * {{enumDescription}}
+   */
+     {{/enumDescription}}
+  {{{name}}}({{{value}}}){{^-last}},
+  {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
+
+  private {{{dataType}}} value;
+
+  {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}({{{dataType}}} value) {
+    this.value = value;
+  }
+
+{{#jackson}}
+  @JsonValue
+{{/jackson}}
+  public {{{dataType}}} getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+{{#jackson}}
+  @JsonCreator
+{{/jackson}}
+  public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue({{{dataType}}} value) {
+    for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+      if (b.value.equals(value)) {
+        return b;
+      }
+    }
+    {{#isNullable}}return null;{{/isNullable}}{{^isNullable}}throw new IllegalArgumentException("Unexpected value '" + value + "'");{{/isNullable}}
+  }
+{{#gson}}
+
+  public static class Adapter extends TypeAdapter<{{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}> {
+    @Override
+    public void write(final JsonWriter jsonWriter, final {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} enumeration) throws IOException {
+      jsonWriter.value(enumeration.getValue());
+    }
+
+    @Override
+    public {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} read(final JsonReader jsonReader) throws IOException {
+      {{^isNumber}}{{{dataType}}}{{/isNumber}}{{#isNumber}}String{{/isNumber}} value = jsonReader.{{#isNumber}}nextString(){{/isNumber}}{{#isInteger}}nextInt(){{/isInteger}}{{^isNumber}}{{^isInteger}}next{{{dataType}}}(){{/isInteger}}{{/isNumber}};
+      return {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.fromValue({{#isNumber}}new BigDecimal({{/isNumber}}value{{#isNumber}}){{/isNumber}});
+    }
+  }
+{{/gson}}
+}

--- a/src/main/templates/modelInnerEnum.mustache
+++ b/src/main/templates/modelInnerEnum.mustache
@@ -1,0 +1,64 @@
+  /**
+   * {{^description}}Gets or Sets {{{name}}}{{/description}}{{#description}}{{description}}{{/description}}
+   */
+{{#gson}}
+  @JsonAdapter({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.Adapter.class)
+{{/gson}}
+  public enum {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} {
+    {{#allowableValues}}
+      {{#enumVars}}
+    {{#enumDescription}}
+    /**
+     * {{enumDescription}}
+     */
+    {{/enumDescription}}
+    {{{name}}}({{{value}}}){{^-last}},
+    {{/-last}}{{#-last}};{{/-last}}
+      {{/enumVars}}
+    {{/allowableValues}}
+
+    private {{{dataType}}} value;
+
+    {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}({{{dataType}}} value) {
+      this.value = value;
+    }
+
+{{#jackson}}
+    @JsonValue
+{{/jackson}}
+    public {{{dataType}}} getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(value);
+    }
+
+{{#jackson}}
+    @JsonCreator
+{{/jackson}}
+    public static {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue({{{dataType}}} value) {
+      for ({{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      {{#isNullable}}return null;{{/isNullable}}{{^isNullable}}throw new IllegalArgumentException("Unexpected value '" + value + "'");{{/isNullable}}
+    }
+{{#gson}}
+
+    public static class Adapter extends TypeAdapter<{{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}> {
+      @Override
+      public void write(final JsonWriter jsonWriter, final {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} enumeration) throws IOException {
+        jsonWriter.value(enumeration.getValue());
+      }
+
+      @Override
+      public {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}} read(final JsonReader jsonReader) throws IOException {
+        {{^isNumber}}{{{dataType}}}{{/isNumber}}{{#isNumber}}String{{/isNumber}} value = {{#isFloat}}(float){{/isFloat}} jsonReader.{{#isNumber}}nextString(){{/isNumber}}{{#isInteger}}nextInt(){{/isInteger}}{{^isNumber}}{{^isInteger}}{{#isFloat}}nextDouble{{/isFloat}}{{^isFloat}}next{{{dataType}}}{{/isFloat}}(){{/isInteger}}{{/isNumber}};
+        return {{#datatypeWithEnum}}{{{.}}}{{/datatypeWithEnum}}{{^datatypeWithEnum}}{{classname}}{{/datatypeWithEnum}}.fromValue({{#isNumber}}new BigDecimal({{/isNumber}}value{{#isNumber}}){{/isNumber}});
+      }
+    }
+{{/gson}}
+  }

--- a/src/main/templates/pojo.mustache
+++ b/src/main/templates/pojo.mustache
@@ -1,0 +1,369 @@
+/**
+ * {{#description}}{{.}}{{/description}}{{^description}}{{classname}}{{/description}}
+ */{{#description}}
+@ApiModel(description = "{{{description}}}"){{/description}}
+{{#jackson}}
+@JsonPropertyOrder({
+{{#vars}}
+  {{classname}}.JSON_PROPERTY_{{nameInSnakeCase}}{{^-last}},{{/-last}}
+{{/vars}}
+})
+{{/jackson}}
+{{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}{{>xmlAnnotation}}
+public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcelableModel}}implements Parcelable {{#serializableModel}}, Serializable {{/serializableModel}}{{/parcelableModel}}{{^parcelableModel}}{{#serializableModel}}implements Serializable {{/serializableModel}}{{/parcelableModel}}{
+{{#serializableModel}}
+  private static final long serialVersionUID = 1L;
+
+{{/serializableModel}}
+  {{#vars}}
+    {{#isEnum}}
+    {{^isContainer}}
+{{>modelInnerEnum}}
+    {{/isContainer}}
+    {{#isContainer}}
+    {{#mostInnerItems}}
+{{>modelInnerEnum}}
+    {{/mostInnerItems}}
+    {{/isContainer}}
+    {{/isEnum}}
+  {{#gson}}
+  public static final String SERIALIZED_NAME_{{nameInSnakeCase}} = "{{baseName}}";
+  {{/gson}}
+  {{#jackson}}
+  public static final String JSON_PROPERTY_{{nameInSnakeCase}} = "{{baseName}}";
+  {{/jackson}}
+  {{#withXml}}
+  {{#isXmlAttribute}}
+  @XmlAttribute(name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+  {{/isXmlAttribute}}
+  {{^isXmlAttribute}}
+    {{^isContainer}}
+  @XmlElement({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+    {{/isContainer}}
+    {{#isContainer}}
+  // Is a container wrapped={{isXmlWrapped}}
+      {{#items}}
+  // items.name={{name}} items.baseName={{baseName}} items.xmlName={{xmlName}} items.xmlNamespace={{xmlNamespace}}
+  // items.example={{example}} items.type={{dataType}}
+  @XmlElement({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+      {{/items}}
+      {{#isXmlWrapped}}
+  @XmlElementWrapper({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{baseName}}{{/xmlName}}")
+      {{/isXmlWrapped}}
+    {{/isContainer}}
+  {{/isXmlAttribute}}
+  {{/withXml}}
+  {{#gson}}
+  @SerializedName(SERIALIZED_NAME_{{nameInSnakeCase}})
+  {{/gson}}
+  {{#vendorExtensions.isJacksonOptionalNullable}}
+  {{#isContainer}}
+  private JsonNullable<{{{datatypeWithEnum}}}> {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>undefined();
+  {{/isContainer}}
+  {{^isContainer}}
+  private JsonNullable<{{{datatypeWithEnum}}}> {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>{{#defaultValue}}of({{{.}}}){{/defaultValue}}{{^defaultValue}}undefined(){{/defaultValue}};
+  {{/isContainer}}
+  {{/vendorExtensions.isJacksonOptionalNullable}}
+  {{^vendorExtensions.isJacksonOptionalNullable}}
+  {{#isContainer}}
+  private {{{datatypeWithEnum}}} {{name}}{{#required}}{{#defaultValue}} = {{{.}}}{{/defaultValue}}{{/required}}{{^required}} = null{{/required}};
+  {{/isContainer}}
+  {{^isContainer}}
+  private {{{datatypeWithEnum}}} {{name}}{{#defaultValue}} = {{{.}}}{{/defaultValue}};
+  {{/isContainer}}
+  {{/vendorExtensions.isJacksonOptionalNullable}}
+
+  {{/vars}}
+  {{#parcelableModel}}
+  public {{classname}}() {
+  {{#parent}}
+    super();
+  {{/parent}}
+  {{#gson}}
+  {{#discriminator}}
+    this.{{{discriminatorName}}} = this.getClass().getSimpleName();
+  {{/discriminator}}
+  {{/gson}}
+  }
+  {{/parcelableModel}}
+  {{^parcelableModel}}
+  {{#gson}}
+  {{#discriminator}}
+  public {{classname}}() {
+    this.{{{discriminatorName}}} = this.getClass().getSimpleName();
+  }
+  {{/discriminator}}
+  {{/gson}}
+  {{/parcelableModel}}
+  {{#vars}}
+
+  {{^isReadOnly}}
+  public {{classname}} {{name}}({{{datatypeWithEnum}}} {{name}}) {
+    {{#vendorExtensions.isJacksonOptionalNullable}}this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{name}});{{/vendorExtensions.isJacksonOptionalNullable}}
+    {{^vendorExtensions.isJacksonOptionalNullable}}this.{{name}} = {{name}};{{/vendorExtensions.isJacksonOptionalNullable}}
+    return this;
+  }
+  {{#isListContainer}}
+
+  public {{classname}} add{{nameInCamelCase}}Item({{{items.datatypeWithEnum}}} {{name}}Item) {
+    {{#vendorExtensions.isJacksonOptionalNullable}}
+    if (this.{{name}} == null || !this.{{name}}.isPresent()) {
+      this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{{defaultValue}}});
+    }
+    try {
+      this.{{name}}.get().add({{name}}Item);
+    } catch (java.util.NoSuchElementException e) {
+      // this can never happen, as we make sure above that the value is present
+    }
+    return this;
+    {{/vendorExtensions.isJacksonOptionalNullable}}
+    {{^vendorExtensions.isJacksonOptionalNullable}}
+    {{^required}}
+    if (this.{{name}} == null) {
+      this.{{name}} = {{{defaultValue}}};
+    }
+    {{/required}}
+    this.{{name}}.add({{name}}Item);
+    return this;
+    {{/vendorExtensions.isJacksonOptionalNullable}}
+  }
+  {{/isListContainer}}
+  {{#isMapContainer}}
+
+  public {{classname}} put{{nameInCamelCase}}Item(String key, {{{items.datatypeWithEnum}}} {{name}}Item) {
+    {{#vendorExtensions.isJacksonOptionalNullable}}
+    if (this.{{name}} == null || !this.{{name}}.isPresent()) {
+      this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{{defaultValue}}});
+    }
+    try {
+      this.{{name}}.get().put(key, {{name}}Item);
+    } catch (java.util.NoSuchElementException e) {
+      // this can never happen, as we make sure above that the value is present
+    }
+    return this;
+    {{/vendorExtensions.isJacksonOptionalNullable}}
+    {{^vendorExtensions.isJacksonOptionalNullable}}
+    {{^required}}
+    if (this.{{name}} == null) {
+      this.{{name}} = {{{defaultValue}}};
+    }
+    {{/required}}
+    this.{{name}}.put(key, {{name}}Item);
+    return this;
+    {{/vendorExtensions.isJacksonOptionalNullable}}
+  }
+  {{/isMapContainer}}
+
+  {{/isReadOnly}}
+   /**
+  {{#description}}
+   * {{description}}
+  {{/description}}
+  {{^description}}
+   * Get {{name}}
+  {{/description}}
+  {{#minimum}}
+   * minimum: {{minimum}}
+  {{/minimum}}
+  {{#maximum}}
+   * maximum: {{maximum}}
+  {{/maximum}}
+   * @return {{name}}
+  **/
+{{#required}}
+{{#isNullable}}
+  @javax.annotation.Nullable
+{{/isNullable}}
+{{/required}}
+{{^required}}
+  @javax.annotation.Nullable
+{{/required}}
+{{#useBeanValidation}}{{>beanValidation}}{{/useBeanValidation}}  @ApiModelProperty({{#example}}example = "{{{example}}}", {{/example}}{{#required}}required = {{required}}, {{/required}}value = "{{{description}}}")
+{{#vendorExtensions.extraAnnotation}}
+  {{{vendorExtensions.extraAnnotation}}}
+{{/vendorExtensions.extraAnnotation}}
+{{#vendorExtensions.isJacksonOptionalNullable}}
+  {{!unannotated, Jackson would pick this up automatically and add it *in addition* to the _JsonNullable getter field}}
+  @JsonIgnore
+{{/vendorExtensions.isJacksonOptionalNullable}}
+{{^vendorExtensions.isJacksonOptionalNullable}}{{#jackson}}{{> jackson_annotations}}{{/jackson}}{{/vendorExtensions.isJacksonOptionalNullable}}
+  public {{{datatypeWithEnum}}} {{getter}}() {
+    {{#vendorExtensions.isJacksonOptionalNullable}}
+    {{#isReadOnly}}{{! A readonly attribute doesn't have setter => jackson will set null directly if explicitly returned by API, so make sure we have an empty JsonNullable}}
+    if ({{name}} == null) {
+      {{name}} = JsonNullable.<{{{datatypeWithEnum}}}>{{#defaultValue}}of({{{.}}}){{/defaultValue}}{{^defaultValue}}undefined(){{/defaultValue}};
+    }
+    {{/isReadOnly}}
+    return {{name}}.orElse(null);
+    {{/vendorExtensions.isJacksonOptionalNullable}}
+    {{^vendorExtensions.isJacksonOptionalNullable}}
+    return {{name}};
+    {{/vendorExtensions.isJacksonOptionalNullable}}
+  }
+
+  {{#vendorExtensions.isJacksonOptionalNullable}}
+{{> jackson_annotations}}
+  public JsonNullable<{{{datatypeWithEnum}}}> {{getter}}_JsonNullable() {
+    return {{name}};
+  }
+  {{/vendorExtensions.isJacksonOptionalNullable}}{{#vendorExtensions.isJacksonOptionalNullable}}
+  @JsonProperty(JSON_PROPERTY_{{nameInSnakeCase}})
+  {{#isReadOnly}}private{{/isReadOnly}}{{^isReadOnly}}public{{/isReadOnly}} void {{setter}}_JsonNullable(JsonNullable<{{{datatypeWithEnum}}}> {{name}}) {
+    {{! For getters/setters that have name differing from attribute name, we must include setter (albeit private) for jackson to be able to set the attribute}}
+    this.{{name}} = {{name}};
+  }
+  {{/vendorExtensions.isJacksonOptionalNullable}}
+
+  {{^isReadOnly}}
+  public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
+    {{#vendorExtensions.isJacksonOptionalNullable}}
+    this.{{name}} = JsonNullable.<{{{datatypeWithEnum}}}>of({{name}});
+    {{/vendorExtensions.isJacksonOptionalNullable}}
+    {{^vendorExtensions.isJacksonOptionalNullable}}
+    this.{{name}} = {{name}};
+    {{/vendorExtensions.isJacksonOptionalNullable}}
+  }
+  {{/isReadOnly}}
+
+  {{/vars}}
+
+{{^supportJava6}}
+  @Override
+  public boolean equals(java.lang.Object o) {
+  {{#useReflectionEqualsHashCode}}
+    return EqualsBuilder.reflectionEquals(this, o, false, null, true);
+  {{/useReflectionEqualsHashCode}}
+  {{^useReflectionEqualsHashCode}}
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }{{#hasVars}}
+    {{classname}} {{classVarName}} = ({{classname}}) o;
+    return {{#vars}}{{#isByteArray}}Arrays{{/isByteArray}}{{^isByteArray}}Objects{{/isByteArray}}.equals(this.{{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
+        {{/hasMore}}{{/vars}}{{#parent}} &&
+        super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
+    return {{#parent}}super.equals(o){{/parent}}{{^parent}}true{{/parent}};{{/hasVars}}
+  {{/useReflectionEqualsHashCode}}
+  }
+
+  @Override
+  public int hashCode() {
+  {{#useReflectionEqualsHashCode}}
+    return HashCodeBuilder.reflectionHashCode(this);
+  {{/useReflectionEqualsHashCode}}
+  {{^useReflectionEqualsHashCode}}
+    return Objects.hash({{#vars}}{{^isByteArray}}{{name}}{{/isByteArray}}{{#isByteArray}}Arrays.hashCode({{name}}){{/isByteArray}}{{#hasMore}}, {{/hasMore}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}});
+  {{/useReflectionEqualsHashCode}}
+  }
+
+{{/supportJava6}}
+{{#supportJava6}}
+  @Override
+  public boolean equals(java.lang.Object o) {
+  if (this == o) {
+    return true;
+  }
+  if (o == null || getClass() != o.getClass()) {
+    return false;
+  }{{#hasVars}}
+    {{classname}} {{classVarName}} = ({{classname}}) o;
+    return {{#vars}}ObjectUtils.equals(this.{{name}}, {{classVarName}}.{{name}}){{#hasMore}} &&
+    {{/hasMore}}{{/vars}}{{#parent}} &&
+    super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
+    return true;{{/hasVars}}
+  }
+
+  @Override
+  public int hashCode() {
+    return ObjectUtils.hashCodeMulti({{#vars}}{{name}}{{#hasMore}}, {{/hasMore}}{{/vars}}{{#parent}}{{#hasVars}}, {{/hasVars}}super.hashCode(){{/parent}});
+  }
+
+{{/supportJava6}}
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class {{classname}} {\n");
+    {{#parent}}
+    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    {{/parent}}
+    {{#vars}}
+    sb.append("    {{name}}: ").append(toIndentedString({{name}})).append("\n");
+    {{/vars}}
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+
+{{#parcelableModel}}
+
+  public void writeToParcel(Parcel out, int flags) {
+{{#model}}
+{{#isArrayModel}}
+    out.writeList(this);
+{{/isArrayModel}}
+{{^isArrayModel}}
+{{#parent}}
+    super.writeToParcel(out, flags);
+{{/parent}}
+{{#vars}}
+    out.writeValue({{name}});
+{{/vars}}
+{{/isArrayModel}}
+{{/model}}
+  }
+
+  {{classname}}(Parcel in) {
+{{#isArrayModel}}
+    in.readTypedList(this, {{arrayModelType}}.CREATOR);
+{{/isArrayModel}}
+{{^isArrayModel}}
+{{#parent}}
+    super(in);
+{{/parent}}
+{{#vars}}
+{{#isPrimitiveType}}
+    {{name}} = ({{{datatypeWithEnum}}})in.readValue(null);
+{{/isPrimitiveType}}
+{{^isPrimitiveType}}
+    {{name}} = ({{{datatypeWithEnum}}})in.readValue({{complexType}}.class.getClassLoader());
+{{/isPrimitiveType}}
+{{/vars}}
+{{/isArrayModel}}
+  }
+
+  public int describeContents() {
+    return 0;
+  }
+
+  public static final Parcelable.Creator<{{classname}}> CREATOR = new Parcelable.Creator<{{classname}}>() {
+    public {{classname}} createFromParcel(Parcel in) {
+{{#model}}
+{{#isArrayModel}}
+      {{classname}} result = new {{classname}}();
+      result.addAll(in.readArrayList({{arrayModelType}}.class.getClassLoader()));
+      return result;
+{{/isArrayModel}}
+{{^isArrayModel}}
+      return new {{classname}}(in);
+{{/isArrayModel}}
+{{/model}}
+    }
+    public {{classname}}[] newArray(int size) {
+      return new {{classname}}[size];
+    }
+  };
+{{/parcelableModel}}
+}

--- a/src/main/templates/xmlAnnotation.mustache
+++ b/src/main/templates/xmlAnnotation.mustache
@@ -1,0 +1,6 @@
+{{#withXml}}
+
+@XmlRootElement({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}name = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{classname}}{{/xmlName}}")
+@XmlAccessorType(XmlAccessType.FIELD)
+{{#jackson}}
+@JacksonXmlRootElement({{#xmlNamespace}}namespace="{{xmlNamespace}}", {{/xmlNamespace}}localName = "{{#xmlName}}{{xmlName}}{{/xmlName}}{{^xmlName}}{{classname}}{{/xmlName}}"){{/jackson}}{{/withXml}}

--- a/src/main/webapp/api/index.html
+++ b/src/main/webapp/api/index.html
@@ -3,7 +3,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>Swagger UI</title>
+    <title>ds-storage API</title>
     <link rel="stylesheet" type="text/css" href="../v1/swagger-ui.css" >
     <link rel="icon" type="image/png" href="../v1/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="../v1/favicon-16x16.png" sizes="16x16" />

--- a/src/test/jetty/jetty-env.xml
+++ b/src/test/jetty/jetty-env.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_10_0.dtd">
 <Configure class="org.eclipse.jetty.webapp.WebAppContext">
 
     <New id="logback" class="org.eclipse.jetty.plus.jndi.EnvEntry">


### PR DESCRIPTION
First part of general refresh of ds-services.

Same as for ds-datahandler:

* jetty bumped to latest version, autoscan (aka hot redeploy)
* kb-util bumped to latest version, removal of multiple redundant files and adjustment of code
* Logging on debug of webservice call information for all endpoints
* Syncing of latest mustache templates
* Use the name of the service as title for the OpenAPI Admin GUI