### PR TITLE
Disc 328 storage record typer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>dk.kb.storage</groupId>
     <artifactId>ds-storage</artifactId>
-    <version>1.5</version>
+    <version>1.6-SNAPSHOT</version>
     <packaging>war</packaging>
     <description>
     # Ds-storage(Digitale Samlinger) by the Royal Danish Library. 
@@ -76,7 +76,7 @@
         <url>https://github.com/kb-dk/ds-storage</url>
         <connection>scm:git:git@github.com:kb-dk/ds-storage.git</connection>
         <developerConnection>scm:git:git@github.com:kb-dk/ds-storage.git</developerConnection>
-        <tag>ds-storage-1.5</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
     Every origin is configured with a transitive  update strategy that makes sense for the origin. When a record is created or update it can update the mTime of parent and all children
     if defined for the origin. The possible updatestrategies are: NONE, ALL, PARENT, CHILDREN.  (see #updatestrategy schema)
         
+    ## Record type
+    Records must have one of the 3 enum types define in RecordTypeDto. The recordtype is an easy way to determine depth in the hierachy and can be collection specific.
+    COLLECTION This is top parent (root) with information about the collection. 
+    DELIVERABLEUNIT Parent for a manifestation.
+    MANIFESTATION A record that has metadata that relates to single digital preservation unit (image, video, audio etc.).          
+        
     ## API   
     Records can be extracted by recordId or as a list by specified origin and last modification time (mTime). The uniqueness of mTime
     will ensure batching through the records using mTime will not return same record twice.  

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>dk.kb.storage</groupId>
     <artifactId>ds-storage</artifactId>
-    <version>1.4</version>
+    <version>1.5-SNAPSHOT</version>
     <packaging>war</packaging>
     <description>
     # Ds-storage(Digitale Samlinger) by the Royal Danish Library. 
@@ -76,7 +76,7 @@
         <url>https://github.com/kb-dk/ds-storage</url>
         <connection>scm:git:git@github.com:kb-dk/ds-storage.git</connection>
         <developerConnection>scm:git:git@github.com:kb-dk/ds-storage.git</developerConnection>
-        <tag>ds-storage-1.4</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>dk.kb.storage</groupId>
     <artifactId>ds-storage</artifactId>
-    <version>1.5-SNAPSHOT</version>
+    <version>1.5</version>
     <packaging>war</packaging>
     <description>
     # Ds-storage(Digitale Samlinger) by the Royal Danish Library. 
@@ -76,7 +76,7 @@
         <url>https://github.com/kb-dk/ds-storage</url>
         <connection>scm:git:git@github.com:kb-dk/ds-storage.git</connection>
         <developerConnection>scm:git:git@github.com:kb-dk/ds-storage.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>ds-storage-1.5</tag>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>dk.kb.storage</groupId>
     <artifactId>ds-storage</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>1.4</version>
     <packaging>war</packaging>
     <description>
     # Ds-storage(Digitale Samlinger) by the Royal Danish Library. 
@@ -76,7 +76,7 @@
         <url>https://github.com/kb-dk/ds-storage</url>
         <connection>scm:git:git@github.com:kb-dk/ds-storage.git</connection>
         <developerConnection>scm:git:git@github.com:kb-dk/ds-storage.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>ds-storage-1.4</tag>
     </scm>
 
     <licenses>

--- a/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
+++ b/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
@@ -140,7 +140,7 @@ public class DsStorageApiServiceImpl extends ImplBase implements DsStorageApi {
         try {
             log.debug(" getRecordsByRecordTypeModifiedAfterLocalTree(origin='{}', recordtype='{}', mTime={}, maxRecords={}) with batchSize={} " +
                       "called with call details: {}",
-                      origin, mTime, maxRecords, ServiceConfig.getDBBatchSize(), getCallDetails());
+                      origin, recordType, mTime, maxRecords, ServiceConfig.getDBBatchSize(), getCallDetails());
             // Both mTime and maxRecords defaults should be set in the OpenAPI YAML, but the current version of
             // the OpenAPI generator does not support defaults for longs (int64)
             long finalMTime = mTime == null ? 0L : mTime;

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -16,6 +16,7 @@ import dk.kb.storage.config.ServiceConfig;
 import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.storage.model.v1.OriginCountDto;
 import dk.kb.storage.model.v1.OriginDto;
+import dk.kb.storage.model.v1.RecordTypeDto;
 import dk.kb.storage.model.v1.UpdateStrategyDto;
 import dk.kb.storage.storage.DsStorage;
 import dk.kb.storage.util.IdNormaliser;
@@ -31,9 +32,9 @@ public class DsStorageFacade {
 
     public static void createOrUpdateRecord(DsRecordDto record)  {
         performStorageAction("createOrUpdateRecord(" + record.getId() + ")", storage -> {
-            validateOriginExists(record.getOrigin());
+            validateOriginExists(record.getOrigin());        
             validateIdHasOriginPrefix(record.getOrigin(), record.getId());
-            
+            validateRecordType(record.getRecordType());
             String orgId = record.getId();
             if (record.getParentId() != null) { //Parent ID must belong to same collection and also validate
               validateIdHasOriginPrefix(record.getOrigin(), record.getParentId());
@@ -331,7 +332,17 @@ public class DsStorageFacade {
         }
     }
     
-
+    /**
+     * RecordType is not null
+     * @param origin name.
+     */
+    private static void validateRecordType(RecordTypeDto type) {
+        if (type==null) {
+            throw new InvalidArgumentServiceException("RecordType must not be null");
+        }
+    }
+    
+    
     /**
      * Starts a storage transaction and performs the given action on it, returning the result from the action.
      *

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -378,8 +378,9 @@ public class DsStorageFacade {
     }
     
     /**
-     * RecordType is not null
-     * @param origin name.
+     * Validate recordType is not null
+     * 
+     * @param type 
      */
     private static void validateRecordType(RecordTypeDto type) {
         if (type==null) {

--- a/src/main/java/dk/kb/storage/storage/DsStorage.java
+++ b/src/main/java/dk/kb/storage/storage/DsStorage.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 
 import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.storage.model.v1.OriginCountDto;
+import dk.kb.storage.model.v1.RecordTypeDto;
 import dk.kb.storage.util.UniqueTimestampGenerator;
 
 
@@ -36,6 +37,7 @@ public class DsStorage implements AutoCloseable {
     private static final String ORGID_COLUMN = "orgid";
     private static final String IDERROR_COLUMN = "id_error";
     private static final String ORIGIN_COLUMN = "origin";
+    private static final String RECORDTYPE_COLUMN = "recordtype";
     private static final String DELETED_COLUMN = "deleted";
     private static final String DATA_COLUMN = "data";
     private static final String CTIME_COLUMN = "ctime";
@@ -46,8 +48,8 @@ public class DsStorage implements AutoCloseable {
 
 
     private static String createRecordStatement = "INSERT INTO " + RECORDS_TABLE +
-            " (" + ID_COLUMN + ", " + ORIGIN_COLUMN + ", " +ORGID_COLUMN +"," + IDERROR_COLUMN +","+ DELETED_COLUMN + ", " + CTIME_COLUMN + ", " + MTIME_COLUMN + ", " + DATA_COLUMN + ", " + PARENT_ID_COLUMN +  ")"+
-            " VALUES (?,?,?,?,?,?,?,?,?)";
+            " (" + ID_COLUMN + ", " + ORIGIN_COLUMN + ", " +ORGID_COLUMN + ","+ RECORDTYPE_COLUMN +"," + IDERROR_COLUMN +","+ DELETED_COLUMN + ", " + CTIME_COLUMN + ", " + MTIME_COLUMN + ", " + DATA_COLUMN + ", " + PARENT_ID_COLUMN +  ")"+
+            " VALUES (?,?,?,?,?,?,?,?,?,?)";
 
     private static String updateRecordStatement = "UPDATE " + RECORDS_TABLE + " SET  "+			 
             DATA_COLUMN + " = ? , "+ 						 
@@ -353,12 +355,13 @@ public class DsStorage implements AutoCloseable {
             stmt.setString(1, record.getId());
             stmt.setString(2, record.getOrigin());
             stmt.setString(3, record.getOrgid());                        
-            stmt.setInt(4, boolToInt(record.getIdError()));            
-            stmt.setInt(5, 0);
-            stmt.setLong(6, nowStamp);
+            stmt.setString(4, record.getRecordType().getValue());
+            stmt.setInt(5, boolToInt(record.getIdError()));                
+            stmt.setInt(6, 0);
             stmt.setLong(7, nowStamp);
-            stmt.setString(8, record.getData());
-            stmt.setString(9, record.getParentId());
+            stmt.setLong(8, nowStamp);
+            stmt.setString(9, record.getData());
+            stmt.setString(10, record.getParentId());
             stmt.executeUpdate();
 
         } catch (SQLException e) {
@@ -471,6 +474,7 @@ public class DsStorage implements AutoCloseable {
         String origin = rs.getString(ORIGIN_COLUMN);
         boolean idError = rs.getInt(IDERROR_COLUMN) == 1;
         String orgid = rs.getString(ORGID_COLUMN);
+        String recordType = rs.getString(RECORDTYPE_COLUMN);
         boolean deleted = rs.getInt(DELETED_COLUMN) == 1;		                
         String data = rs.getString(DATA_COLUMN);
         long cTime = rs.getLong(CTIME_COLUMN);
@@ -481,6 +485,7 @@ public class DsStorage implements AutoCloseable {
         record.setId(id);
         record.setOrigin(origin);
         record.setOrgid(orgid);
+        record.setRecordType(RecordTypeDto.valueOf(recordType));
         record.setIdError(idError);
         record.setData(data);
         record.setParentId(parentId);

--- a/src/main/java/dk/kb/storage/storage/DsStorage.java
+++ b/src/main/java/dk/kb/storage/storage/DsStorage.java
@@ -52,10 +52,11 @@ public class DsStorage implements AutoCloseable {
             " VALUES (?,?,?,?,?,?,?,?,?,?)";
 
     private static String updateRecordStatement = "UPDATE " + RECORDS_TABLE + " SET  "+			 
+            RECORDTYPE_COLUMN + " = ?  ,"+
             DATA_COLUMN + " = ? , "+ 						 
             MTIME_COLUMN + " = ? , "+
             DELETED_COLUMN + " = 0 , "+
-            PARENT_ID_COLUMN + " = ?  "+
+            PARENT_ID_COLUMN + " = ?  "+            
             "WHERE "+
             ID_COLUMN + "= ?";
 
@@ -454,11 +455,11 @@ public class DsStorage implements AutoCloseable {
         //log.debug("Creating new record: " + record.getId());
 
         try (PreparedStatement stmt = connection.prepareStatement(updateRecordStatement);) {
-
-            stmt.setString(1, record.getData());
-            stmt.setLong(2, nowStamp);						
-            stmt.setString(3, record.getParentId());
-            stmt.setString(4, record.getId());
+            stmt.setString(1, record.getRecordType().getValue());
+            stmt.setString(2, record.getData());
+            stmt.setLong(3, nowStamp);						
+            stmt.setString(4, record.getParentId());
+            stmt.setString(5, record.getId());
             stmt.executeUpdate();
         } catch (SQLException e) {
             String message = "SQL Exception in updateRecord with id:" + record.getId() + " error:" + e.getMessage();

--- a/src/main/openapi/ds-storage-openapi_v1.yaml
+++ b/src/main/openapi/ds-storage-openapi_v1.yaml
@@ -198,6 +198,62 @@ paths:
           description: No Content - The request has been executed correct and the server did not deliver any content.
 
   
+  /recordsByRecordTypeLocalTree:
+    get:
+      tags:
+        - '${project.name}'
+      summary: 'Extract X records from a origin.'
+      description: >
+        Extract X records from a specified origin and recordtype after a given mTime and up to a defined maximum mTime. 
+        The records are returned in sorted order by mTime increasing. Records marked for delete will also be returned.
+        The record will be loaded with the full localtree as objects.         
+      operationId: getRecordsByRecordTypeModifiedAfterLocalTree
+      x-streamingOutput: true
+      parameters:
+        - name: origin
+          in: query
+          description: 'Origin. Will only extract records from this origin'
+          required: true
+          schema:
+            type: string
+        - name: recordType
+          in: query
+          description: 'Only extract records with this recordtype'
+          required: true
+          schema:
+            $ref: '#/components/schemas/RecordType'                      
+        - name: mTime
+          in: query
+          description: >
+            Format is milliseconds with 3 added digits. It is up to the caller to keep track of 
+            mTime when batching the extracting for retrieval between separate calls.
+          required: false
+          schema:
+            type: integer
+            format: int64  
+            example: 0
+            # Default values for longs does not work with the current version of OpenAPI generator
+            #default: 0
+        - name: maxRecords
+          in: query
+          description: 'Maximum number of records to return. -1 means no limit.'
+          required: false
+          schema:
+            type: integer
+            format: int64
+            example: 1000
+            # Default values for longs does not work with the current version of OpenAPI generator
+            #default: 1000
+
+      responses:
+        '200':
+          description: 'List of DsRecords'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DsRecordList'
+
+
   /records:
     get:
       tags:
@@ -245,6 +301,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DsRecordList'
+
 
   # The ping service should be in all projects, should not do any advanced processing
   # and should respond quickly with a simple message, e.g. "pong".

--- a/src/main/openapi/ds-storage-openapi_v1.yaml
+++ b/src/main/openapi/ds-storage-openapi_v1.yaml
@@ -316,6 +316,8 @@ components:
       type: object
       required:
         - id
+        - origin
+        - recordType
       properties:
         id:
           type: string
@@ -329,6 +331,10 @@ components:
         origin:
           type: string
           description: 'Collection name where the record comes from. Lower characters and dot(.) allowed only.'
+        recordType:
+          type: string
+          description: 'Optional. Examples can be deliverableunit, collection or metadata. Use metadata for records that contains the data. Collection are parent records without metadata.'
+          $ref: '#/components/schemas/RecordType'          
         deleted:
           type: boolean
           description: 'Mark the record as deleted'
@@ -431,6 +437,25 @@ components:
           format: int32
         message:
           type: string
+
+    RecordType:
+      type: string
+      nullable: false
+      description: |
+        
+        **Explanation of the 4 different updatestrategies.**
+        
+        | Enum             |  Description                                                                                 | 
+        | ---------------- | -------------------------------------------------------------------------------------------- |  
+        | METADATA         |  All records in the transitive graphs originating in this object should be marked as updated.| 
+        | COLLECTION       |  Metadata records can be in a collection                                                     |                 
+        | DELIVERABLEUNIT  |  Parent object for metadata   |
+      enum:
+        - METADATA
+        - COLLECTION
+        - DELIVERABLEUNIT
+  
+
 
     # Basic status response component.
     # TODO: Extend this to provide application specific status, such as a list of running jobs or free disk space

--- a/src/main/openapi/ds-storage-openapi_v1.yaml
+++ b/src/main/openapi/ds-storage-openapi_v1.yaml
@@ -445,17 +445,17 @@ components:
         
         **Explanation of the 4 different updatestrategies.**
         
-        | Enum             |  Description                                                                                 | 
-        | ---------------- | -------------------------------------------------------------------------------------------- |  
-        | METADATA         |  All records in the transitive graphs originating in this object should be marked as updated.| 
-        | COLLECTION       |  Metadata records can be in a collection                                                     |                 
-        | DELIVERABLEUNIT  |  Parent object for metadata   |
+        | Enum             |  Description                                                                                  | 
+        | ---------------- | --------------------------------------------------------------------------------------------- |  
+        | COLLECTION       |  Metadata records can be in a collection. This is the root of the tree                        |         
+        | DELIVERABLEUNIT  |  Parent object for manifestation         
+        | MANIFESTATION    |  All records in the transitive graphs originating in this object should be marked as updated.|
+        
       enum:
-        - METADATA
         - COLLECTION
         - DELIVERABLEUNIT
-  
-
+        - MANIFESTATION
+        
 
     # Basic status response component.
     # TODO: Extend this to provide application specific status, such as a list of running jobs or free disk space

--- a/src/test/java/dk/kb/storage/facade/DsStorageFacadeTest.java
+++ b/src/test/java/dk/kb/storage/facade/DsStorageFacadeTest.java
@@ -34,7 +34,7 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
         record.setId(id);
         record.setOrigin(origin);
         record.setData(data);
-        record.setRecordType(RecordTypeDto.METADATA);
+        record.setRecordType(RecordTypeDto.MANIFESTATION);
         DsStorageFacade.createOrUpdateRecord(record );
 
         //Load and see it is marked invalid
@@ -68,7 +68,7 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
         record.setOrigin(origin);
         record.setData(data);
         record.setParentId(parentId);
-        record.setRecordType(RecordTypeDto.METADATA);
+        record.setRecordType(RecordTypeDto.MANIFESTATION);
         DsStorageFacade.createOrUpdateRecord(record );
 
         DsRecordDto recordLoaded = DsStorageFacade.getRecord(id);
@@ -114,7 +114,7 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
         record.setId(id);
         record.setOrigin(origin);
         record.setData(data);
-        record.setRecordType(RecordTypeDto.METADATA);
+        record.setRecordType(RecordTypeDto.MANIFESTATION);
         
         try {
             DsStorageFacade.createOrUpdateRecord(record );
@@ -262,7 +262,7 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
         record.setId(id);
         record.setOrigin(origin);
         record.setData(data);     
-        record.setRecordType(RecordTypeDto.METADATA);
+        record.setRecordType(RecordTypeDto.MANIFESTATION);
         try {
             DsStorageFacade.createOrUpdateRecord(record );
             fail("Should fail with recordId does not have origin as prefix");    
@@ -427,14 +427,14 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
         child1.setOrigin(origin);
         child1.setData("child1 data");
         child1.setParentId(origin+":"+parentId);
-        child1.setRecordType(RecordTypeDto.METADATA);
+        child1.setRecordType(RecordTypeDto.MANIFESTATION);
         
         DsRecordDto child2 = new DsRecordDto();
         child2.setId(origin+":"+"child2");
         child2.setOrigin(origin);
         child2.setData("child2 data");
         child2.setParentId(origin+":"+parentId);
-        child2.setRecordType(RecordTypeDto.METADATA);
+        child2.setRecordType(RecordTypeDto.MANIFESTATION);
         
         DsStorageFacade.createOrUpdateRecord(parentRecord);
         DsStorageFacade.createOrUpdateRecord(child1);
@@ -469,14 +469,14 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
         child1.setOrigin(origin);
         child1.setData("p2 data");
         child1.setParentId(origin+":p1");
-        child1.setRecordType(RecordTypeDto.METADATA);
+        child1.setRecordType(RecordTypeDto.MANIFESTATION);
         
         DsRecordDto child2 = new DsRecordDto();
         child2.setId(origin+":p3");
         child2.setOrigin(origin);
         child2.setData("p3 data");
         child2.setParentId(origin+":p1"); // This is the loop
-        child2.setRecordType(RecordTypeDto.METADATA);  
+        child2.setRecordType(RecordTypeDto.MANIFESTATION);  
         
         DsStorageFacade.createOrUpdateRecord(parentRecord);
         DsStorageFacade.createOrUpdateRecord(child1);
@@ -513,28 +513,28 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
         c1.setOrigin(origin);
         c1.setData("c1 data");
         c1.setParentId(origin+":"+parentId);
-        c1.setRecordType(RecordTypeDto.METADATA);
+        c1.setRecordType(RecordTypeDto.MANIFESTATION);
         
         DsRecordDto c2 = new DsRecordDto();
         c2.setId(origin+":"+"c2");
         c2.setOrigin(origin);
         c2.setData("child2 data");
         c2.setParentId(origin+":"+parentId);
-        c2.setRecordType(RecordTypeDto.METADATA);
+        c2.setRecordType(RecordTypeDto.MANIFESTATION);
         
         DsRecordDto c1_1 = new DsRecordDto();
         c1_1.setId(origin+":"+"c1_1");
         c1_1.setOrigin(origin);
         c1_1.setData("c1_1 data");
         c1_1.setParentId(c1.getId()); //c1 as parent
-        c1_1.setRecordType(RecordTypeDto.METADATA);
+        c1_1.setRecordType(RecordTypeDto.MANIFESTATION);
         
         DsRecordDto c1_2 = new DsRecordDto();
         c1_2.setId(origin+":"+"c1_2");
         c1_2.setOrigin(origin);
         c1_2.setData("c1_2 data");
         c1_2.setParentId(c1.getId()); // c1 as parent
-        c1_2.setRecordType(RecordTypeDto.METADATA);
+        c1_2.setRecordType(RecordTypeDto.MANIFESTATION);
         
         DsStorageFacade.createOrUpdateRecord(p);
         DsStorageFacade.createOrUpdateRecord(c1);

--- a/src/test/java/dk/kb/storage/facade/DsStorageFacadeTest.java
+++ b/src/test/java/dk/kb/storage/facade/DsStorageFacadeTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import dk.kb.storage.facade.DsStorageFacade;
 import dk.kb.storage.model.v1.DsRecordDto;
+import dk.kb.storage.model.v1.RecordTypeDto;
 import dk.kb.storage.storage.DsStorageUnitTestUtil;
 import dk.kb.util.webservice.exception.InternalServiceException;
 
@@ -33,6 +34,7 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
         record.setId(id);
         record.setOrigin(origin);
         record.setData(data);
+        record.setRecordType(RecordTypeDto.METADATA);
         DsStorageFacade.createOrUpdateRecord(record );
 
         //Load and see it is marked invalid
@@ -66,6 +68,7 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
         record.setOrigin(origin);
         record.setData(data);
         record.setParentId(parentId);
+        record.setRecordType(RecordTypeDto.METADATA);
         DsStorageFacade.createOrUpdateRecord(record );
 
         DsRecordDto recordLoaded = DsStorageFacade.getRecord(id);
@@ -111,6 +114,7 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
         record.setId(id);
         record.setOrigin(origin);
         record.setData(data);
+        record.setRecordType(RecordTypeDto.METADATA);
         
         try {
             DsStorageFacade.createOrUpdateRecord(record );
@@ -257,7 +261,8 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
         DsRecordDto record = new DsRecordDto();
         record.setId(id);
         record.setOrigin(origin);
-        record.setData(data);        
+        record.setData(data);     
+        record.setRecordType(RecordTypeDto.METADATA);
         try {
             DsStorageFacade.createOrUpdateRecord(record );
             fail("Should fail with recordId does not have origin as prefix");    
@@ -415,19 +420,22 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
         parentRecord.setId(origin+":"+parentId);
         parentRecord.setOrigin(origin);
         parentRecord.setData("parent data");
-
+        parentRecord.setRecordType(RecordTypeDto.COLLECTION);
+        
         DsRecordDto child1 = new DsRecordDto();
         child1.setId(origin+":"+"child1");
         child1.setOrigin(origin);
         child1.setData("child1 data");
         child1.setParentId(origin+":"+parentId);
-
+        child1.setRecordType(RecordTypeDto.METADATA);
+        
         DsRecordDto child2 = new DsRecordDto();
         child2.setId(origin+":"+"child2");
         child2.setOrigin(origin);
         child2.setData("child2 data");
         child2.setParentId(origin+":"+parentId);
-
+        child2.setRecordType(RecordTypeDto.METADATA);
+        
         DsStorageFacade.createOrUpdateRecord(parentRecord);
         DsStorageFacade.createOrUpdateRecord(child1);
         DsStorageFacade.createOrUpdateRecord(child2);
@@ -453,19 +461,23 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
         parentRecord.setOrigin(origin);
         parentRecord.setData("p1 data");
         parentRecord.setParentId(origin+":p3");
+        parentRecord.setRecordType(RecordTypeDto.COLLECTION);
+        
         
         DsRecordDto child1 = new DsRecordDto();
         child1.setId(origin+":p2");
         child1.setOrigin(origin);
         child1.setData("p2 data");
         child1.setParentId(origin+":p1");
-
+        child1.setRecordType(RecordTypeDto.METADATA);
+        
         DsRecordDto child2 = new DsRecordDto();
         child2.setId(origin+":p3");
         child2.setOrigin(origin);
         child2.setData("p3 data");
         child2.setParentId(origin+":p1"); // This is the loop
-                
+        child2.setRecordType(RecordTypeDto.METADATA);  
+        
         DsStorageFacade.createOrUpdateRecord(parentRecord);
         DsStorageFacade.createOrUpdateRecord(child1);
         DsStorageFacade.createOrUpdateRecord(child2);        
@@ -494,32 +506,35 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
         p.setId(origin+":"+parentId);
         p.setOrigin(origin);
         p.setData("parent data");
-
+        p.setRecordType(RecordTypeDto.COLLECTION);
+        
         DsRecordDto c1 = new DsRecordDto();
         c1.setId(origin+":"+"c1");
         c1.setOrigin(origin);
         c1.setData("c1 data");
         c1.setParentId(origin+":"+parentId);
-
+        c1.setRecordType(RecordTypeDto.METADATA);
+        
         DsRecordDto c2 = new DsRecordDto();
         c2.setId(origin+":"+"c2");
         c2.setOrigin(origin);
         c2.setData("child2 data");
         c2.setParentId(origin+":"+parentId);
-
+        c2.setRecordType(RecordTypeDto.METADATA);
         
         DsRecordDto c1_1 = new DsRecordDto();
         c1_1.setId(origin+":"+"c1_1");
         c1_1.setOrigin(origin);
         c1_1.setData("c1_1 data");
         c1_1.setParentId(c1.getId()); //c1 as parent
+        c1_1.setRecordType(RecordTypeDto.METADATA);
         
         DsRecordDto c1_2 = new DsRecordDto();
         c1_2.setId(origin+":"+"c1_2");
         c1_2.setOrigin(origin);
         c1_2.setData("c1_2 data");
         c1_2.setParentId(c1.getId()); // c1 as parent
-        
+        c1_2.setRecordType(RecordTypeDto.METADATA);
         
         DsStorageFacade.createOrUpdateRecord(p);
         DsStorageFacade.createOrUpdateRecord(c1);

--- a/src/test/java/dk/kb/storage/storage/DsStorageTest.java
+++ b/src/test/java/dk/kb/storage/storage/DsStorageTest.java
@@ -200,6 +200,10 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
 
         ArrayList<String> childIds = storage.getChildrenIds(parentId);
         assertEquals(1000, childIds.size());	        	      
+                
+        //Load with children and record at once.
+        DsRecordDto recordsWithChildren = storage.loadRecordWithChildIds(parentId);                         
+        Assertions.assertEquals(1000, recordsWithChildren.getChildrenIds().size());                
     }
 
     /*

--- a/src/test/java/dk/kb/storage/storage/DsStorageTest.java
+++ b/src/test/java/dk/kb/storage/storage/DsStorageTest.java
@@ -39,14 +39,14 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         String origin="origin.test";	    	
         String data = "Hello";
         String parentId="origin.test:id_1_parent";
-        RecordTypeDto recordType=RecordTypeDto.METADATA;
+        RecordTypeDto recordType=RecordTypeDto.MANIFESTATION;
         
         DsRecordDto record = new DsRecordDto();
         record.setId(id);
         record.setOrigin(origin);
         record.setData(data);
         record.setParentId(parentId);
-        record.setRecordType(RecordTypeDto.METADATA);
+        record.setRecordType(RecordTypeDto.MANIFESTATION);
         storage.createNewRecord(record );
 
         //Test record not exist
@@ -223,7 +223,7 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
             child.setOrigin(origin);
             child.setData("child data "+i);
             child.setParentId(id);
-            child.setRecordType(RecordTypeDto.METADATA);
+            child.setRecordType(RecordTypeDto.MANIFESTATION);
 
             storage.createNewRecord(child);	            	        
         }
@@ -238,28 +238,28 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         r1.setId("Id1"); //TODO 
         r1.setOrigin("test_origin1");
         r1.setData("id1 text");   			
-        r1.setRecordType(RecordTypeDto.METADATA);
+        r1.setRecordType(RecordTypeDto.MANIFESTATION);
         storage.createNewRecord(r1);
 
         DsRecordDto r2 = new DsRecordDto();
         r2.setId("Id2");
         r2.setOrigin("test_origin1");
         r2.setData("id2 text");   				    	
-        r2.setRecordType(RecordTypeDto.METADATA);
+        r2.setRecordType(RecordTypeDto.MANIFESTATION);
         storage.createNewRecord(r2);
 
         DsRecordDto r3 = new DsRecordDto();
         r3.setId("Id3");
         r3.setOrigin("test_origin2");
         r3.setData("id3 text");   				    	
-        r3.setRecordType(RecordTypeDto.METADATA);        
+        r3.setRecordType(RecordTypeDto.MANIFESTATION);        
         storage.createNewRecord(r3);
 
         DsRecordDto r4 = new DsRecordDto();
         r4.setId("Id4");
         r4.setOrigin("test_origin3");
         r4.setData("id4 text");
-        r4.setRecordType(RecordTypeDto.METADATA);
+        r4.setRecordType(RecordTypeDto.MANIFESTATION);
         storage.createNewRecord(r4);
 
         ArrayList<OriginCountDto> originStatisticsList = storage.getOriginStatictics();

--- a/src/test/java/dk/kb/storage/storage/DsStorageTest.java
+++ b/src/test/java/dk/kb/storage/storage/DsStorageTest.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.storage.model.v1.OriginCountDto;
+import dk.kb.storage.model.v1.RecordTypeDto;
 import dk.kb.storage.util.UniqueTimestampGenerator;
 
 
@@ -38,12 +39,14 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         String origin="origin.test";	    	
         String data = "Hello";
         String parentId="origin.test:id_1_parent";
-
+        RecordTypeDto recordType=RecordTypeDto.METADATA;
+        
         DsRecordDto record = new DsRecordDto();
         record.setId(id);
         record.setOrigin(origin);
         record.setData(data);
         record.setParentId(parentId);
+        record.setRecordType(RecordTypeDto.METADATA);
         storage.createNewRecord(record );
 
         //Test record not exist
@@ -58,7 +61,7 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         Assertions.assertEquals(parentId,record.getParentId());        
         Assertions.assertTrue(recordLoaded.getmTime() > 0);
         Assertions.assertEquals(recordLoaded.getcTime(), recordLoaded.getmTime());                  
-
+        Assertions.assertEquals(recordType, recordLoaded.getRecordType());
 
         //Now update
 
@@ -210,7 +213,8 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         megaParent.setOrigin(origin);
         megaParent.setData("mega_parent_data");
         megaParent.setParentId(null);
-
+        megaParent.setRecordType(RecordTypeDto.COLLECTION);
+        
         storage.createNewRecord(megaParent);
 
         for (int i=1;i<=1000;i++){	        
@@ -219,7 +223,7 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
             child.setOrigin(origin);
             child.setData("child data "+i);
             child.setParentId(id);
-
+            child.setRecordType(RecordTypeDto.METADATA);
 
             storage.createNewRecord(child);	            	        
         }
@@ -233,25 +237,29 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         DsRecordDto r1 = new DsRecordDto();
         r1.setId("Id1"); //TODO 
         r1.setOrigin("test_origin1");
-        r1.setData("id1 text");   				    	
+        r1.setData("id1 text");   			
+        r1.setRecordType(RecordTypeDto.METADATA);
         storage.createNewRecord(r1);
 
         DsRecordDto r2 = new DsRecordDto();
         r2.setId("Id2");
         r2.setOrigin("test_origin1");
         r2.setData("id2 text");   				    	
+        r2.setRecordType(RecordTypeDto.METADATA);
         storage.createNewRecord(r2);
 
         DsRecordDto r3 = new DsRecordDto();
         r3.setId("Id3");
         r3.setOrigin("test_origin2");
         r3.setData("id3 text");   				    	
+        r3.setRecordType(RecordTypeDto.METADATA);        
         storage.createNewRecord(r3);
 
         DsRecordDto r4 = new DsRecordDto();
         r4.setId("Id4");
         r4.setOrigin("test_origin3");
-        r4.setData("id4 text");   				    	
+        r4.setData("id4 text");
+        r4.setRecordType(RecordTypeDto.METADATA);
         storage.createNewRecord(r4);
 
         ArrayList<OriginCountDto> originStatisticsList = storage.getOriginStatictics();

--- a/src/test/resources/ddl/create_ds_storage.ddl
+++ b/src/test/resources/ddl/create_ds_storage.ddl
@@ -7,11 +7,13 @@ deleted INTEGER,
 data TEXT,
 ctime BIGINT,
 mtime BIGINT,
-parentId VARCHAR(255)
+parentid VARCHAR(255),
+recordtype VARCHAR(31)
 );
 
 CREATE UNIQUE INDEX i ON ds_records(id);
 CREATE UNIQUE INDEX m ON ds_records(mtime);
 CREATE INDEX b ON ds_records(origin);
 CREATE INDEX bd ON ds_records(origin,deleted);
-CREATE INDEX p ON ds_records(parentId);
+CREATE INDEX p ON ds_records(parentid);
+CREATE INDEX rt ON ds_records(recordtype);

--- a/src/test/resources/ddl/create_ds_storage_h2_unittest.ddl
+++ b/src/test/resources/ddl/create_ds_storage_h2_unittest.ddl
@@ -7,11 +7,13 @@ deleted INTEGER,
 data TEXT,
 ctime BIGINT,
 mtime BIGINT,
-parentId VARCHAR(255)
+parentid VARCHAR(255),
+recordtype VARCHAR(31)
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS i ON ds_records(id);
 CREATE UNIQUE INDEX IF NOT EXISTS m ON ds_records(mtime);
 CREATE INDEX IF NOT EXISTS b ON ds_records(origin);
 CREATE INDEX IF NOT EXISTS bd ON ds_records(origin,deleted);
-CREATE INDEX IF NOT EXISTS p ON ds_records(parentId);
+CREATE INDEX IF NOT EXISTS p ON ds_records(parentid);
+CREATE INDEX IF NOT EXISTS rt ON ds_records(recordtype);


### PR DESCRIPTION
There is only 1 new method, but also some refactoring that makes the PR looks much bigger.
Only review this new method on openAPI.
Example call (some of the records have a parent which is loaded)
http://devel11:10001/ds-storage/v1/recordsByRecordTypeLocalTree?origin=ds.radiotv&recordType=MANIFESTATION&mTime=0&maxRecords=10

And new method implemeting this
DsStorageFacade.getRecordsByRecordTypeModifiedAfterWithLocalTree 
And a new method in 
DsStorage.getRecordsIdsByRecordTypeModifiedAfter  <- only extracts ID for the batching, then load the full object tree later.

