### PR TITLE
Streaming in the client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ conf/ds-storage-environment.yaml
 conf/ds-storage-local.yaml
 setup_project.sh
 /.openapi-generator-ignore
+/src/test/resources/kb-internal-test.yaml

--- a/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
+++ b/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
@@ -124,6 +124,8 @@ public class DsStorageApiServiceImpl extends ImplBase implements DsStorageApi {
                 // https://github.com/swagger-api/swagger-ui/issues/3832
                 httpServletResponse.setHeader("Content-Disposition", "inline; swaggerDownload=\"attachment\"; filename=\"" + filename + "\"");
             }
+
+            // This is currently a place holder for future functionality
             // TODO: Implement method for returning highest mTime
             httpServletResponse.setHeader(HEADER_HIGHEST_MTIME, "123456");
 
@@ -160,6 +162,8 @@ public class DsStorageApiServiceImpl extends ImplBase implements DsStorageApi {
                 // https://github.com/swagger-api/swagger-ui/issues/3832
                 httpServletResponse.setHeader("Content-Disposition", "inline; swaggerDownload=\"attachment\"; filename=\"" + filename + "\"");
             }
+
+            // This is currently a place holder for future functionality
             // TODO: Implement method for returning highest mTime
             httpServletResponse.setHeader(HEADER_HIGHEST_MTIME, "123456");
 

--- a/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
+++ b/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
@@ -7,11 +7,9 @@ import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.storage.model.v1.OriginCountDto;
 import dk.kb.storage.model.v1.OriginDto;
 import dk.kb.storage.model.v1.RecordTypeDto;
+import dk.kb.util.webservice.ImplBase;
 import dk.kb.util.webservice.stream.ExportWriter;
 import dk.kb.util.webservice.stream.ExportWriterFactory;
-import dk.kb.util.webservice.ImplBase;
-import dk.kb.util.webservice.exception.NotFoundServiceException;
-
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,13 +18,7 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.Request;
-import javax.ws.rs.core.SecurityContext;
-import javax.ws.rs.core.StreamingOutput;
-import javax.ws.rs.core.UriInfo;
+import javax.ws.rs.core.*;
 import javax.ws.rs.ext.Providers;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,6 +32,15 @@ import java.util.List;
  *
  */
 public class DsStorageApiServiceImpl extends ImplBase implements DsStorageApi {
+    /**
+     * Set as header by record streaming endpoints to communicate the highest mTime that any records will contain.
+     * This always means the mTime for the last record in the stream.
+     * <p>
+     * Note that there is no preceeding {@code X-} as this is discouraged by
+     * <a href="https://www.rfc-editor.org/rfc/rfc6648">rfc6648</a>.
+     */
+    public static final String HEADER_HIGHEST_MTIME = "Highest-mTime";
+
     private Logger log = LoggerFactory.getLogger(this.toString());
 
     /*
@@ -123,6 +124,8 @@ public class DsStorageApiServiceImpl extends ImplBase implements DsStorageApi {
                 // https://github.com/swagger-api/swagger-ui/issues/3832
                 httpServletResponse.setHeader("Content-Disposition", "inline; swaggerDownload=\"attachment\"; filename=\"" + filename + "\"");
             }
+            // TODO: Implement method for returning highest mTime
+            httpServletResponse.setHeader(HEADER_HIGHEST_MTIME, "123456");
 
             return output -> {
                 try (ExportWriter writer = ExportWriterFactory.wrap(
@@ -157,6 +160,8 @@ public class DsStorageApiServiceImpl extends ImplBase implements DsStorageApi {
                 // https://github.com/swagger-api/swagger-ui/issues/3832
                 httpServletResponse.setHeader("Content-Disposition", "inline; swaggerDownload=\"attachment\"; filename=\"" + filename + "\"");
             }
+            // TODO: Implement method for returning highest mTime
+            httpServletResponse.setHeader(HEADER_HIGHEST_MTIME, "123456");
 
             return output -> {
                 try (ExportWriter writer = ExportWriterFactory.wrap(

--- a/src/main/java/dk/kb/storage/util/DsStorageClient.java
+++ b/src/main/java/dk/kb/storage/util/DsStorageClient.java
@@ -81,7 +81,9 @@ public class DsStorageClient extends DsStorageApi {
     }
 
     /**
-     * Delivers a stream of records from a call to a remote ds-storage {@link #getRecordsModifiedAfter}.
+     * Call the remote ds-storage {@link #getRecordsModifiedAfter} and return the response in the form of a Stream 
+     * of records.
+     * <p>
      * The stream is unbounded by memory and gives access to the highest modification time (microseconds since
      * Epoch 1970) for any record that will be delivered by the stream.
      * <p>
@@ -102,10 +104,11 @@ public class DsStorageClient extends DsStorageApi {
     }
 
     /**
-     * Delivers a stream of records from a call to a remote ds-storage
-     * {@link #getRecordsByRecordTypeModifiedAfterLocalTree}.
+     * Call the remote ds-storage {@link #getRecordsByRecordTypeModifiedAfterLocalTree} and return the response
+     * in the form of a Stream of records.
+     * <p>
      * The stream is unbounded by memory and gives access to the highest modification time (microseconds since
-     * Epoch 1970) for any record that will be delivered by the stream.
+     * Epoch 1970) for any record that will be delivered by the stream {@link RecordStream#getHighestModificationTime}.
      * <p>
      * Important: Ensure that the returned stream is closed to avoid resource leaks.
      * @param origin     the origin for the records.
@@ -126,7 +129,8 @@ public class DsStorageClient extends DsStorageApi {
     }
 
     /**
-     * Delivers the raw bytestream from a call to a remote ds-storage {@link #getRecordsModifiedAfter}.
+     * Call the remote ds-storage {@link #getRecordsModifiedAfter} and return the response unchanged as a wrapped
+     * bytestream.
      * <p>
      * Important: Ensure that the returned stream is closed to avoid resource leaks.
      * @param origin     the origin for the records.
@@ -148,8 +152,8 @@ public class DsStorageClient extends DsStorageApi {
     }
 
     /**
-     * Delivers the raw bytestream from a call to a remote ds-storage
-     * {@link #getRecordsByRecordTypeModifiedAfterLocalTree}.
+     * Call the remote ds-storage {@link #getRecordsByRecordTypeModifiedAfterLocalTree} and return the response 
+     * unchanged as a wrapped bytestream.
      * <p>
      * Important: Ensure that the returned stream is closed to avoid resource leaks.
      * @param origin     the origin for the records.
@@ -273,8 +277,8 @@ public class DsStorageClient extends DsStorageApi {
 
     /**
      * {@link DsRecordDto} specific stream that gives access to the highest modification time for any record
-     * that will be in the stream (not just up to the current point). The highest modification time will always
-     * belong to the last record in the stream.
+     * that will be in the stream (not just up to the current {@link DsRecordDto} in the stream).
+     * The highest modification time will always belong to the last record in the stream.
      */
     public static class RecordStream extends FilterStream<DsRecordDto> implements AutoCloseable {
         private final String highestModificationTime;

--- a/src/main/java/dk/kb/storage/util/FilterStream.java
+++ b/src/main/java/dk/kb/storage/util/FilterStream.java
@@ -1,0 +1,281 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.storage.util;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.function.*;
+import java.util.stream.*;
+
+/**
+ * {@code Stream} equivalent of {@link java.io.FilterInputStream} for easy extension of {@link Stream}s.
+ * All methods delegates to the given inner {@code Stream}.
+ */
+public class FilterStream<T> implements Stream<T> {
+    private final Stream<T> inner;
+
+    public FilterStream(Stream<T> inner) {
+        this.inner = inner;
+    }
+
+    @Override
+    public Stream<T> filter(Predicate<? super T> predicate) {
+        return inner.filter(predicate);
+    }
+
+    @Override
+    public <R> Stream<R> map(Function<? super T, ? extends R> function) {
+        return inner.map(function);
+    }
+
+    @Override
+    public IntStream mapToInt(ToIntFunction<? super T> toIntFunction) {
+        return inner.mapToInt(toIntFunction);
+    }
+
+    @Override
+    public LongStream mapToLong(ToLongFunction<? super T> toLongFunction) {
+        return inner.mapToLong(toLongFunction);
+    }
+
+    @Override
+    public DoubleStream mapToDouble(ToDoubleFunction<? super T> toDoubleFunction) {
+        return inner.mapToDouble(toDoubleFunction);
+    }
+
+    @Override
+    public <R> Stream<R> flatMap(Function<? super T, ? extends Stream<? extends R>> function) {
+        return inner.flatMap(function);
+    }
+
+    @Override
+    public IntStream flatMapToInt(Function<? super T, ? extends IntStream> function) {
+        return inner.flatMapToInt(function);
+    }
+
+    @Override
+    public LongStream flatMapToLong(Function<? super T, ? extends LongStream> function) {
+        return inner.flatMapToLong(function);
+    }
+
+    @Override
+    public DoubleStream flatMapToDouble(Function<? super T, ? extends DoubleStream> function) {
+        return inner.flatMapToDouble(function);
+    }
+
+    @Override
+    public Stream<T> distinct() {
+        return inner.distinct();
+    }
+
+    @Override
+    public Stream<T> sorted() {
+        return inner.sorted();
+    }
+
+    @Override
+    public Stream<T> sorted(Comparator<? super T> comparator) {
+        return inner.sorted(comparator);
+    }
+
+    @Override
+    public Stream<T> peek(Consumer<? super T> consumer) {
+        return inner.peek(consumer);
+    }
+
+    @Override
+    public Stream<T> limit(long l) {
+        return inner.limit(l);
+    }
+
+    @Override
+    public Stream<T> skip(long l) {
+        return inner.skip(l);
+    }
+
+    @Override
+    public Stream<T> takeWhile(Predicate<? super T> predicate) {
+        return inner.takeWhile(predicate);
+    }
+
+    @Override
+    public Stream<T> dropWhile(Predicate<? super T> predicate) {
+        return inner.dropWhile(predicate);
+    }
+
+    @Override
+    public void forEach(Consumer<? super T> consumer) {
+        inner.forEach(consumer);
+    }
+
+    @Override
+    public void forEachOrdered(Consumer<? super T> consumer) {
+        inner.forEachOrdered(consumer);
+    }
+
+    @Override
+    public Object[] toArray() {
+        return inner.toArray();
+    }
+
+    @Override
+    public <A> A[] toArray(IntFunction<A[]> intFunction) {
+        return inner.toArray(intFunction);
+    }
+
+    @Override
+    public T reduce(T t, BinaryOperator<T> binaryOperator) {
+        return inner.reduce(t, binaryOperator);
+    }
+
+    @Override
+    public Optional<T> reduce(BinaryOperator<T> binaryOperator) {
+        return inner.reduce(binaryOperator);
+    }
+
+    @Override
+    public <U> U reduce(U u, BiFunction<U, ? super T, U> biFunction, BinaryOperator<U> binaryOperator) {
+        return inner.reduce(u, biFunction, binaryOperator);
+    }
+
+    @Override
+    public <R> R collect(Supplier<R> supplier, BiConsumer<R, ? super T> biConsumer, BiConsumer<R, R> biConsumer1) {
+        return inner.collect(supplier, biConsumer, biConsumer1);
+    }
+
+    @Override
+    public <R, A> R collect(Collector<? super T, A, R> collector) {
+        return inner.collect(collector);
+    }
+
+    @Override
+    public Optional<T> min(Comparator<? super T> comparator) {
+        return inner.min(comparator);
+    }
+
+    @Override
+    public Optional<T> max(Comparator<? super T> comparator) {
+        return inner.max(comparator);
+    }
+
+    @Override
+    public long count() {
+        return inner.count();
+    }
+
+    @Override
+    public boolean anyMatch(Predicate<? super T> predicate) {
+        return inner.anyMatch(predicate);
+    }
+
+    @Override
+    public boolean allMatch(Predicate<? super T> predicate) {
+        return inner.allMatch(predicate);
+    }
+
+    @Override
+    public boolean noneMatch(Predicate<? super T> predicate) {
+        return inner.noneMatch(predicate);
+    }
+
+    @Override
+    public Optional<T> findFirst() {
+        return inner.findFirst();
+    }
+
+    @Override
+    public Optional<T> findAny() {
+        return inner.findAny();
+    }
+
+    public static <T1> Builder<T1> builder() {
+        return Stream.builder();
+    }
+
+    public static <T1> Stream<T1> empty() {
+        return Stream.empty();
+    }
+
+    public static <T1> Stream<T1> of(T1 t1) {
+        return Stream.of(t1);
+    }
+
+    public static <T1> Stream<T1> ofNullable(T1 t1) {
+        return Stream.ofNullable(t1);
+    }
+
+    @SafeVarargs
+    public static <T1> Stream<T1> of(T1... values) {
+        return Stream.of(values);
+    }
+
+    public static <T1> Stream<T1> iterate(T1 seed, UnaryOperator<T1> f) {
+        return Stream.iterate(seed, f);
+    }
+
+    public static <T1> Stream<T1> iterate(T1 seed, Predicate<? super T1> hasNext, UnaryOperator<T1> next) {
+        return Stream.iterate(seed, hasNext, next);
+    }
+
+    public static <T1> Stream<T1> generate(Supplier<? extends T1> s) {
+        return Stream.generate(s);
+    }
+
+    public static <T1> Stream<T1> concat(Stream<? extends T1> a, Stream<? extends T1> b) {
+        return Stream.concat(a, b);
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return inner.iterator();
+    }
+
+    @Override
+    public Spliterator<T> spliterator() {
+        return inner.spliterator();
+    }
+
+    @Override
+    public boolean isParallel() {
+        return inner.isParallel();
+    }
+
+    @Override
+    public Stream<T> sequential() {
+        return inner.sequential();
+    }
+
+    @Override
+    public Stream<T> parallel() {
+        return inner.parallel();
+    }
+
+    @Override
+    public Stream<T> unordered() {
+        return inner.unordered();
+    }
+
+    @Override
+    public Stream<T> onClose(Runnable runnable) {
+        return inner.onClose(runnable);
+    }
+
+    @Override
+    public void close() {
+        inner.close();
+    }
+}

--- a/src/main/java/dk/kb/storage/util/HeaderInputStream.java
+++ b/src/main/java/dk/kb/storage/util/HeaderInputStream.java
@@ -1,0 +1,67 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.storage.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * HTTP specific {@link InputStream} wrapper that keeps track of the headers returned by the server.
+ */
+public class HeaderInputStream extends FilterInputStream implements AutoCloseable {
+    private static final Logger log = LoggerFactory.getLogger(HeaderInputStream.class);
+
+    private final Map<String, List<String>> headers;
+
+    /**
+     * Establish a connection to the given {@code uri}, extract all headers and construct a
+     * {@link HeaderInputStream} with the headers and response stream from the {@code uri}.
+     * @param uri full URI for a call to a webservice.
+     * @return an {@code InputStream} with the response.
+     * @throws IOException if the connection failed.
+     */
+    public static HeaderInputStream from(URI uri) throws IOException {
+        log.debug("Opening streaming connection to '{}'", uri);
+        HttpURLConnection con = (HttpURLConnection) uri.toURL().openConnection();
+        con.setInstanceFollowRedirects(true);
+        int status = con.getResponseCode();
+        if (status < 200 || status > 299) {
+            throw new IOException("Got HTTP " + status + " establishing connection to '" + uri + "'");
+            // TODO: Consider if the error stream should be logged. It can be arbitrarily large
+        }
+        Map<String, List<String>> headers = con.getHeaderFields();
+        return new HeaderInputStream(headers, con.getInputStream());
+    }
+
+    private HeaderInputStream(Map<String, List<String>> headers, InputStream in) {
+        super(in);
+        this.headers = headers;
+    }
+
+    /**
+     * @return headers from the established connection.
+     */
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+}

--- a/src/test/java/dk/kb/storage/util/DsStorageClientTest.java
+++ b/src/test/java/dk/kb/storage/util/DsStorageClientTest.java
@@ -15,21 +15,22 @@
 package dk.kb.storage.util;
 
 import dk.kb.storage.model.v1.DsRecordDto;
-import dk.kb.storage.util.DsStorageClient;
+import dk.kb.storage.model.v1.RecordTypeDto;
+import dk.kb.util.yaml.YAML;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.CharSequenceInputStream;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.StringBufferInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Simple verification of client code generation.
@@ -37,18 +38,84 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class DsStorageClientTest {
     private static final Logger log = LoggerFactory.getLogger(DsStorageClientTest.class);
 
+    public static final String TEST_CONF = "internal-test-setup.yaml";
+
     public static final String RECORD1 = "{\"id\": \"id1\", \"mTime\": \"123\"}";
     public static final String RECORD2 = "{\"id\": \"id2\", \"mTime\": \"124\"}";
     public static final String RECORDS0 = "[]";
     public static final String RECORDS1 = "[" + RECORD1 + "]";
     public static final String RECORDS2 = "[" + RECORD1 + ", " + RECORD2 + "]";
 
-    // We cannot test usage as that would require a running instance of ds-storage to connect to
+    private static DsStorageClient remote = getRemote();
+
+    @BeforeAll
+    public static void beforeClass() {
+        remote = getRemote();
+    }
+
     @Test
     public void testInstantiation() {
         String backendURIString = "htp://example.com/ds-storage/v1";
         log.debug("Creating inactive client for ds-storage with URI '{}'", backendURIString);
         new DsStorageClient(backendURIString);
+    }
+
+    @Test
+    public void testRemoteRecordsRaw() throws IOException {
+        if (remote == null) {
+            return;
+        }
+        try (HeaderInputStream recordsIS = remote.getRecordsModifiedAfterRaw(
+                "ds.radiotv", 0L, 3L)) {
+            String recordsStr = IOUtils.toString(recordsIS, StandardCharsets.UTF_8);
+            assertTrue(recordsStr.contains("\"id\":\"ds.radiotv:oai"),
+                    "At least 1 JSON block for a record should be returned");
+            assertNotNull(recordsIS.getHeaders().get(DsStorageClient.HEADER_HIGHEST_MTIME),
+                    "The continuation header '" + DsStorageClient.HEADER_HIGHEST_MTIME + "' should be present");
+        }
+    }
+
+    @Test
+    public void testRemoteRecordsTreeRaw() throws IOException {
+        if (remote == null) {
+            return;
+        }
+        try (HeaderInputStream recordsIS = remote.getRecordsByRecordTypeModifiedAfterLocalTreeRaw(
+                             "ds.radiotv", RecordTypeDto.DELIVERABLEUNIT,  0L, 3L)) {
+            String recordsStr = IOUtils.toString(recordsIS, StandardCharsets.UTF_8);
+            assertTrue(recordsStr.contains("\"id\":\"ds.radiotv:oai"),
+                    "At least 1 JSON block for a record should be returned");
+            assertNotNull(recordsIS.getHeaders().get(DsStorageClient.HEADER_HIGHEST_MTIME),
+                    "The continuation header '" + DsStorageClient.HEADER_HIGHEST_MTIME + "' should be present");
+        }
+    }
+
+    @Test
+    public void testRemoteRecordsStream() throws IOException {
+        if (remote == null) {
+            return;
+        }
+        try (DsStorageClient.RecordStream records = remote.getRecordsModifiedAfterStream(
+                "ds.radiotv", 0L, 3L)) {
+            long count = records.count();
+            assertEquals(3L, count, "The requested number of records should be received");
+            assertNotNull(records.getHighestModificationTime(),
+                    "The highest modification time should be present");
+        }
+    }
+
+    @Test
+    public void testRemoteRecordsTreeStream() throws IOException {
+        if (remote == null) {
+            return;
+        }
+        try (DsStorageClient.RecordStream records = remote.getRecordsByRecordTypeModifiedAfterLocalTreeStream(
+                "ds.radiotv", RecordTypeDto.DELIVERABLEUNIT, 0L, 3L)) {
+            long count = records.count();
+            assertEquals(3L, count, "The requested number of records should be received");
+            assertNotNull(records.getHighestModificationTime(),
+                    "The highest modification time should be present");
+        }
     }
 
     @Test
@@ -81,4 +148,33 @@ public class DsStorageClientTest {
             assertEquals("id2", records.get(1).getId(), "The second record should have the expected ID");
         }
     }
+
+    /**
+     * @return a {@link DsStorageClient} if a KB-internal remote storage is specified and is available.
+     */
+    private static DsStorageClient getRemote() {
+        YAML config;
+        try {
+            config = YAML.resolveLayeredConfigs(TEST_CONF);
+        } catch (Exception e) {
+            log.info("Unable to resolve '{}' (try running 'kb init'). Skipping test", TEST_CONF);
+            return null;
+        }
+        String storageURL = config.getString(DsStorageClient.STORAGE_SERVER_URL_KEY, null);
+        if (storageURL == null) {
+            log.info("Resolved internal config '{}' but could not retrieve a value for key '{}'. Skipping test",
+                    TEST_CONF, DsStorageClient.STORAGE_SERVER_URL_KEY);
+            return null;
+        }
+        DsStorageClient client = new DsStorageClient(storageURL);
+        try {
+            client.getOriginConfiguration();
+        } catch (Exception e) {
+            log.info("Found ds-storage address '{}' but could not establish contact. Skipping test", storageURL);
+            return null;
+        }
+        log.debug("Established connection to storage at '{}'", storageURL);
+        return client;
+    }
+
 }

--- a/src/test/java/dk/kb/storage/util/DsStorageClientTest.java
+++ b/src/test/java/dk/kb/storage/util/DsStorageClientTest.java
@@ -14,10 +14,22 @@
  */
 package dk.kb.storage.util;
 
+import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.storage.util.DsStorageClient;
+import org.apache.commons.io.input.CharSequenceInputStream;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.StringBufferInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Simple verification of client code generation.
@@ -25,11 +37,45 @@ import org.slf4j.LoggerFactory;
 public class DsStorageClientTest {
     private static final Logger log = LoggerFactory.getLogger(DsStorageClientTest.class);
 
+    public static final String RECORD1 = "{\"id\": \"id1\", \"mTime\": \"123\"}";
+    public static final String RECORD2 = "{\"id\": \"id2\", \"mTime\": \"124\"}";
+    public static final String RECORDS0 = "[]";
+    public static final String RECORDS1 = "[" + RECORD1 + "]";
+    public static final String RECORDS2 = "[" + RECORD1 + ", " + RECORD2 + "]";
+
     // We cannot test usage as that would require a running instance of ds-storage to connect to
     @Test
     public void testInstantiation() {
         String backendURIString = "htp://example.com/ds-storage/v1";
         log.debug("Creating inactive client for ds-storage with URI '{}'", backendURIString);
         new DsStorageClient(backendURIString);
+    }
+
+    @Test
+    public void testRecords0() throws IOException {
+        Stream<DsRecordDto> deserialized = DsStorageClient.bytesToRecordStream(
+                new CharSequenceInputStream(RECORDS0, StandardCharsets.UTF_8, 1024));
+        List<DsRecordDto> records = deserialized.collect(Collectors.toList());
+        assertTrue(records.isEmpty(), "There should be no records, but there were " + records.size());
+    }
+
+    @Test
+    public void testRecords1() throws IOException {
+        Stream<DsRecordDto> deserialized = DsStorageClient.bytesToRecordStream(
+                new CharSequenceInputStream(RECORDS1, StandardCharsets.UTF_8, 1024));
+        List<DsRecordDto> records = deserialized.collect(Collectors.toList());
+        assertEquals(1, records.size(), "There should be the right number of records");
+        assertEquals("id1", records.get(0).getId(), "The first record should have the expected ID");
+    }
+
+    @Test
+    public void testRecords2() throws IOException {
+        Stream<DsRecordDto> deserialized = DsStorageClient.bytesToRecordStream(
+                new CharSequenceInputStream(RECORDS2, StandardCharsets.UTF_8, 1024));
+        List<DsRecordDto> records = deserialized.collect(Collectors.toList());
+        assertEquals(2, records.size(), "There should be the right number of records");
+        assertEquals("id1", records.get(0).getId(), "The first record should have the expected ID");
+        assertEquals(123L, records.get(0).getmTime(), "The first record should have the expected mTime");
+        assertEquals("id2", records.get(1).getId(), "The second record should have the expected ID");
     }
 }

--- a/src/test/java/dk/kb/storage/util/DsStorageClientTest.java
+++ b/src/test/java/dk/kb/storage/util/DsStorageClientTest.java
@@ -53,29 +53,32 @@ public class DsStorageClientTest {
 
     @Test
     public void testRecords0() throws IOException {
-        Stream<DsRecordDto> deserialized = DsStorageClient.bytesToRecordStream(
-                new CharSequenceInputStream(RECORDS0, StandardCharsets.UTF_8, 1024));
-        List<DsRecordDto> records = deserialized.collect(Collectors.toList());
-        assertTrue(records.isEmpty(), "There should be no records, but there were " + records.size());
+        try (Stream<DsRecordDto> deserialized = DsStorageClient.bytesToRecordStream(
+                new CharSequenceInputStream(RECORDS0, StandardCharsets.UTF_8, 1024))) {
+            List<DsRecordDto> records = deserialized.collect(Collectors.toList());
+            assertTrue(records.isEmpty(), "There should be no records, but there were " + records.size());
+        }
     }
 
     @Test
     public void testRecords1() throws IOException {
-        Stream<DsRecordDto> deserialized = DsStorageClient.bytesToRecordStream(
-                new CharSequenceInputStream(RECORDS1, StandardCharsets.UTF_8, 1024));
-        List<DsRecordDto> records = deserialized.collect(Collectors.toList());
-        assertEquals(1, records.size(), "There should be the right number of records");
-        assertEquals("id1", records.get(0).getId(), "The first record should have the expected ID");
+        try (Stream<DsRecordDto> deserialized = DsStorageClient.bytesToRecordStream(
+                new CharSequenceInputStream(RECORDS1, StandardCharsets.UTF_8, 1024))) {
+            List<DsRecordDto> records = deserialized.collect(Collectors.toList());
+            assertEquals(1, records.size(), "There should be the right number of records");
+            assertEquals("id1", records.get(0).getId(), "The first record should have the expected ID");
+        }
     }
 
     @Test
     public void testRecords2() throws IOException {
-        Stream<DsRecordDto> deserialized = DsStorageClient.bytesToRecordStream(
-                new CharSequenceInputStream(RECORDS2, StandardCharsets.UTF_8, 1024));
-        List<DsRecordDto> records = deserialized.collect(Collectors.toList());
-        assertEquals(2, records.size(), "There should be the right number of records");
-        assertEquals("id1", records.get(0).getId(), "The first record should have the expected ID");
-        assertEquals(123L, records.get(0).getmTime(), "The first record should have the expected mTime");
-        assertEquals("id2", records.get(1).getId(), "The second record should have the expected ID");
+        try (Stream<DsRecordDto> deserialized = DsStorageClient.bytesToRecordStream(
+                new CharSequenceInputStream(RECORDS2, StandardCharsets.UTF_8, 1024))) {
+            List<DsRecordDto> records = deserialized.collect(Collectors.toList());
+            assertEquals(2, records.size(), "There should be the right number of records");
+            assertEquals("id1", records.get(0).getId(), "The first record should have the expected ID");
+            assertEquals(123L, records.get(0).getmTime(), "The first record should have the expected mTime");
+            assertEquals("id2", records.get(1).getId(), "The second record should have the expected ID");
+        }
     }
 }


### PR DESCRIPTION
The auto generated client code does not handle streaming, but holds the full result of all calls in memory before passing it to the caller. This pull request adds true streaming (arbitrary result size) support to the `/records` methods, making it simpler to use, e.g. the paging code in `ds-present` can be fully removed.

Additionally first class support for a modification time continuation header has been introduced, but not fully implemented. This will be the subject of a later pull request.