### PR TITLE
Last modified as header

### DIFF
--- a/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
+++ b/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
@@ -125,9 +125,14 @@ public class DsStorageApiServiceImpl extends ImplBase implements DsStorageApi {
                 httpServletResponse.setHeader("Content-Disposition", "inline; swaggerDownload=\"attachment\"; filename=\"" + filename + "\"");
             }
 
-            // This is currently a place holder for future functionality
-            // TODO: Implement method for returning highest mTime
-            httpServletResponse.setHeader(HEADER_HIGHEST_MTIME, "123456");
+            Long highestMtime = DsStorageFacade.getMaxMtimeAfter(origin, finalMTime, finalMaxRecords);
+            if (highestMtime != null) {
+                httpServletResponse.setHeader(HEADER_HIGHEST_MTIME, Long.toString(highestMtime));
+            } else {
+                log.debug("Unable to set header '{}' as max mTime could not be determined for " +
+                          "origin='{}', mTime>{}, maxRecords={}",
+                          HEADER_HIGHEST_MTIME, origin, finalMTime, finalMaxRecords);
+            }
 
             return output -> {
                 try (ExportWriter writer = ExportWriterFactory.wrap(

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
+import dk.kb.util.webservice.exception.ServiceException;
 import dk.kb.util.webservice.stream.ExportWriter;
 
 import org.slf4j.Logger;
@@ -276,6 +277,22 @@ public class DsStorageFacade {
             return numberDeleted;
         });
     }
+
+    /**
+     * Extract max {@code record.mTime}, where {@code record.mTime > mTime} in {@code origin},
+     * ordered by {@code record.mTime} and limited to {@code maxRecords}.
+     * <p>
+     * If there are no matching records, null will be returned.
+     * @param origin only records from the {@code origin} will be inspected.
+     * @param mTime only records with modification time larger than {@code mTime} will be inspected.
+     * @param maxRecords only this number of records will be inspected. {@code -1} means no limit.
+     */
+    public static Long getMaxMtimeAfter(String origin, long mTime, long maxRecords) {
+        return performStorageAction(
+                "getMaxMtimeAfter(origin='" + origin + "', mTime=" + mTime + ", maxRecords=" + maxRecords + ")",
+                storage -> storage.getMaxMtimeAfter(origin, mTime, maxRecords));
+    }
+
 
     /*
      * This is called when ever a record is modified (create/update/markfordelete). The recordId here

--- a/src/test/java/dk/kb/storage/storage/DsStorageTest.java
+++ b/src/test/java/dk/kb/storage/storage/DsStorageTest.java
@@ -1,22 +1,18 @@
 package dk.kb.storage.storage;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import dk.kb.storage.model.v1.DsRecordDto;
 import dk.kb.storage.model.v1.OriginCountDto;
 import dk.kb.storage.model.v1.RecordTypeDto;
 import dk.kb.storage.util.UniqueTimestampGenerator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -34,7 +30,7 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         assertFalse(storage.recordExists("origin:unknown"));
 
         String id ="origin.test:id1";
-        String origin="origin.test";	    	
+        String origin="origin.test";
         String data = "Hello";
         String parentId="origin.test:id_1_parent";
         RecordTypeDto recordType=RecordTypeDto.MANIFESTATION;
@@ -88,14 +84,14 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         Assertions.assertTrue(record_deleted.getDeleted());
 
         //MTime must also be updated when mark for delete  
-        Assertions.assertTrue(recordUpdated.getmTime() < record_deleted.getmTime());		
+        Assertions.assertTrue(recordUpdated.getmTime() < record_deleted.getmTime());
 
         //Update it and deleted flag should be removed
         record.setData("bla bla bla2");
-        storage.updateRecord(record);		
+        storage.updateRecord(record);
         DsRecordDto record_updated_after_delete = storage.loadRecord(id);
 
-        Assertions.assertFalse(record_updated_after_delete.getDeleted());				
+        Assertions.assertFalse(record_updated_after_delete.getDeleted());
 
         //test updateMtime
         int updated = storage.updateMTimeForRecord(id);
@@ -120,7 +116,7 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
 
     @Test
     public void testGetMtimeAfterWithLimit() throws Exception {
-        String parentId="test.origin:mega_parent_id";	          	        
+        String parentId="test.origin:mega_parent_id";
         long beforeTime = UniqueTimestampGenerator.next();
         createMegaParent(parentId,"test.origin");
         long afterTime = UniqueTimestampGenerator.next();
@@ -145,7 +141,15 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         assertTrue(maxBefore < afterTime, "Max mTime with start before should be before afterTime");
         assertTrue(maxBefore < maxMiddle, "Max mTime with start beforeTime should be before max mTime with start in the middle");
         assertTrue(maxMiddle < afterTime, "Max mTime with start in the middle should be before afterTime");
-        assertNull(maxAfter, "Max mTime with start afterTime should be null");
+        assertEquals(0, maxAfter, "Max mTime with start afterTime should be 0");
+        List<DsRecordDto> bRecords = storage.getRecordsModifiedAfter("test.origin", beforeTime, 100);
+
+//        System.out.println("First record: " + bRecords.get(0).getmTime());
+//        System.out.println("Stated mTime: " + maxBefore);
+//        System.out.println("Last  record: " + bRecords.get(bRecords.size()-1).getmTime());
+
+        assertEquals(maxBefore, bRecords.get(bRecords.size()-1).getmTime(),
+                "The mTime for the last bRecord should match maxBefore");
     }
 
     @Test
@@ -171,14 +175,14 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
     }
 
     @Test
-    public void testGetModifiedAfterChildrenOnly() throws Exception {	    
-        String parentId="test.origin:mega_parent_id";	          	        
+    public void testGetModifiedAfterChildrenOnly() throws Exception {
+        String parentId="test.origin:mega_parent_id";
         long before = UniqueTimestampGenerator.next();
 
-        createMegaParent(parentId,"test.origin");	
+        createMegaParent(parentId,"test.origin");
 
         ArrayList<DsRecordDto> list1 = storage.getModifiedAfterChildrenOnly("test.origin.unknown", before, 1000);
-        assertEquals(0, list1.size());	    	 
+        assertEquals(0, list1.size());
 
         ArrayList<DsRecordDto> list2 = storage.getModifiedAfterChildrenOnly("test.origin", before, 1000);
         assertEquals(1000, list2.size());
@@ -195,24 +199,24 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         assertEquals(500, list4.size());
 
         //get next 500
-        long nextTime = list4.get(499).getmTime();	    
+        long nextTime = list4.get(499).getmTime();
         ArrayList<DsRecordDto> list5 = storage.getModifiedAfterChildrenOnly("test.origin", nextTime, 500);
         assertEquals(500, list5.size());
 
         //And no more
-        nextTime = list5.get(499).getmTime();	    	 
+        nextTime = list5.get(499).getmTime();
         ArrayList<DsRecordDto> list6 = storage.getModifiedAfterChildrenOnly("test.origin", nextTime, 500);
-        assertEquals(0, list6.size());	    	 
+        assertEquals(0, list6.size());
     }
 
     
     
     @Test
-    public void testDeleteRecordsForOrigin() throws Exception {	    
-        String parentId="test.origin:mega_parent_id";	          	        
+    public void testDeleteRecordsForOrigin() throws Exception {
+        String parentId="test.origin:mega_parent_id";
         long before = UniqueTimestampGenerator.next();
-        createMegaParent(parentId,"test.origin");	                
-        
+        createMegaParent(parentId,"test.origin");
+
         //Test they are created
         ArrayList<DsRecordDto> list1 = storage.getRecordsModifiedAfter("test.origin", before, 10000);
         assertEquals(1001, list1.size()); //1000 children +1 parent
@@ -232,36 +236,34 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         
         //None left
         ArrayList<DsRecordDto> list3 = storage.getRecordsModifiedAfter("test.origin", before, 10000);
-        assertEquals(0, list3.size()); 
+        assertEquals(0, list3.size());
 
-        
-        
-	    	 	    		    
-    }	    
+
+    }
 
 
     @Test
-    public void testGetModifiedAfter() throws Exception {	    
-        String parentId="test.origin:mega_parent_id";	          	        
+    public void testGetModifiedAfter() throws Exception {
+        String parentId="test.origin:mega_parent_id";
         long before = UniqueTimestampGenerator.next();
 
-        createMegaParent(parentId,"test.origin");	
+        createMegaParent(parentId,"test.origin");
 
         ArrayList<DsRecordDto> list1 = storage.getRecordsModifiedAfter("test.origin", before, 10000);
         assertEquals(1001, list1.size()); //100 children +1 parent	    	 	    		    
-    }	    
+    }
 
     /*
      * Example of parent with 1K children
      */
     @Test
-    public void testManyChildren1K() throws Exception{	    		    		   
-        String parentId="mega_parent_id";	  
+    public void testManyChildren1K() throws Exception{
+        String parentId="mega_parent_id";
         createMegaParent(parentId,"test.origin");
 
         ArrayList<String> childIds = storage.getChildrenIds(parentId);
-        assertEquals(1000, childIds.size());	        	      
-                
+        assertEquals(1000, childIds.size());
+
         //Load with children and record at once.
         DsRecordDto recordsWithChildren = storage.loadRecordWithChildIds(parentId);                         
         Assertions.assertEquals(1000, recordsWithChildren.getChildrenIds().size());                
@@ -282,7 +284,7 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         
         storage.createNewRecord(megaParent);
 
-        for (int i=1;i<=1000;i++){	        
+        for (int i=1;i<=1000;i++){
             DsRecordDto child = new DsRecordDto();
             child.setId(origin+":child"+i);
             child.setOrigin(origin);
@@ -290,7 +292,7 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
             child.setParentId(id);
             child.setRecordType(RecordTypeDto.MANIFESTATION);
 
-            storage.createNewRecord(child);	            	        
+            storage.createNewRecord(child);
         }
 
     }
@@ -302,21 +304,21 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         DsRecordDto r1 = new DsRecordDto();
         r1.setId("Id1"); //TODO 
         r1.setOrigin("test_origin1");
-        r1.setData("id1 text");   			
+        r1.setData("id1 text");
         r1.setRecordType(RecordTypeDto.MANIFESTATION);
         storage.createNewRecord(r1);
 
         DsRecordDto r2 = new DsRecordDto();
         r2.setId("Id2");
         r2.setOrigin("test_origin1");
-        r2.setData("id2 text");   				    	
+        r2.setData("id2 text");
         r2.setRecordType(RecordTypeDto.MANIFESTATION);
         storage.createNewRecord(r2);
 
         DsRecordDto r3 = new DsRecordDto();
         r3.setId("Id3");
         r3.setOrigin("test_origin2");
-        r3.setData("id3 text");   				    	
+        r3.setData("id3 text");
         r3.setRecordType(RecordTypeDto.MANIFESTATION);        
         storage.createNewRecord(r3);
 

--- a/src/test/java/dk/kb/storage/util/DsStorageClientTest.java
+++ b/src/test/java/dk/kb/storage/util/DsStorageClientTest.java
@@ -97,10 +97,14 @@ public class DsStorageClientTest {
         }
         try (DsStorageClient.RecordStream records = remote.getRecordsModifiedAfterStream(
                 "ds.radiotv", 0L, 3L)) {
-            long count = records.count();
-            assertEquals(3L, count, "The requested number of records should be received");
+            List<DsRecordDto> recordList = records.collect(Collectors.toList());
+            assertEquals(3, recordList.size(), "The requested number of records should be received");
             assertNotNull(records.getHighestModificationTime(),
                     "The highest modification time should be present");
+            log.debug("Stated highest modification time was " + records.getHighestModificationTime());
+            assertEquals(recordList.get(recordList.size()-1).getmTime(),
+                    Long.valueOf(records.getHighestModificationTime()),
+                    "Received highest mTime should match stated highest mTime");
         }
     }
 


### PR DESCRIPTION
To support paging with large streams, a continuation token in the form of the modification time for the last records to be delivered should be sent as the header `Highest-mTime`. The skeleton for this already exists, but delivered just a dummy value.

This pull request resolved the proper modification time and sends it with the header.

Note that some of the unit tests in `DsStorageClientTest`requires access to the internal KB-network and expects the ds-storage from the pull branch (`DISC-453_last_modified`) to be deployed on the developer machine (which it is).