### PR TITLE
Revert "Rollback: Collapse the ds.tv and ds.radio origins back to ds.radiotv

### DIFF
--- a/conf/ds-storage-behaviour.yaml
+++ b/conf/ds-storage-behaviour.yaml
@@ -10,13 +10,10 @@ config:
   # update_strategy must match enums defined in open API
   # Origin names must match regexp: a-z][0-9][.] 
   allowed_origins:
-# Ideally radiotv should be split in radio and tv, but currently (2023-11-24) that is unfeasible.
-#    - name: ds.tv
-#      update_strategy: ALL
-#    - name: ds.radio
-#      update_strategy: ALL
-    - name: ds.radiotv
+    - name: ds.tv
       update_strategy: ALL
+    - name: ds.radio
+      update_strategy: ALL           
     - name: doms.radio
       update_strategy: CHILD
     - name: doms.aviser


### PR DESCRIPTION
As we discovered that it **is** possible to split in `radio` and `tv`, this pull request reverts the merging of origins.