### PR TITLE
change <= to < when determining download or inline

### DIFF
--- a/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
+++ b/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
@@ -108,7 +108,7 @@ public class DsStorageApiServiceImpl extends ImplBase implements DsStorageApi {
             long finalMaxRecords = maxRecords == null ? 1000L : maxRecords;
 
             String filename = "records_" + finalMTime + ".json";
-            if (finalMaxRecords <= 2) { // The Swagger GUI is extremely sluggish for inline rendering
+            if (finalMaxRecords < 2) { // The Swagger GUI is extremely sluggish for inline rendering
                 // A few records is ok to show inline in the Swagger GUI:
                 // Show inline in Swagger UI, inline when opened directly in browser
                 httpServletResponse.setHeader("Content-Disposition", "inline; filename=\"" + filename + "\"");
@@ -145,7 +145,7 @@ public class DsStorageApiServiceImpl extends ImplBase implements DsStorageApi {
             long finalMaxRecords = maxRecords == null ? 1000L : maxRecords;
 
             String filename = "records_" + finalMTime + ".json";
-            if (finalMaxRecords <= 2) { // The Swagger GUI is extremely sluggish for inline rendering
+            if (finalMaxRecords < 2) { // The Swagger GUI is extremely sluggish for inline rendering
                 // A few records is ok to show inline in the Swagger GUI:
                 // Show inline in Swagger UI, inline when opened directly in browser
                 httpServletResponse.setHeader("Content-Disposition", "inline; filename=\"" + filename + "\"");


### PR DESCRIPTION
Super small PR changing logical operator when determining to show results inline or download from swagger interface as the `<=` operator didn't work as expected and showed everything inline, which can make browsers hang