### PR TITLE
Disc 774 remove byte array stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Changed how the paging-Record-Count is calculated. A simple database lookup is now performed instead of creating an intermediary stream.
+
 
 ## [1.15](https://github.com/kb-dk/ds-storage/releases/tag/ds-storage-1.15) 2024-02-06
 

--- a/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
+++ b/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
@@ -109,7 +109,7 @@ public class DsStorageApiServiceImpl extends ImplBase implements DsStorageApi {
             long finalMaxRecords = maxRecords == null ? 1000L : maxRecords;
 
             // Count records in the origin we are extracting from
-            long recordsInOrigin = DsStorageFacade.countRecordsInOrigin(origin);
+            long recordsInOrigin = DsStorageFacade.countRecordsInOrigin(origin, finalMTime);
             setHeaders(finalMTime, finalMaxRecords, DsStorageFacade.getMaxMtimeAfter(origin, finalMTime, finalMaxRecords), recordsInOrigin);
 
             return output -> {
@@ -134,7 +134,7 @@ public class DsStorageApiServiceImpl extends ImplBase implements DsStorageApi {
             long finalMTime = mTime == null ? 0L : mTime;
             long finalMaxRecords = maxRecords == null ? 1000L : maxRecords;
 
-            long recordsInOrigin = DsStorageFacade.countRecordsInOrigin(origin);
+            long recordsInOrigin = DsStorageFacade.countRecordsInOrigin(origin, finalMTime);
             setHeaders(finalMTime, finalMaxRecords, DsStorageFacade.getMaxMtimeAfter(origin, finalMTime, finalMaxRecords), recordsInOrigin);
 
             return output -> {

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -77,10 +77,10 @@ public class DsStorageFacade {
      * Get the count of records from a specific origin
      * @param origin to count amount of records from.
      */
-    public static long countRecordsInOrigin(String origin){
+    public static long countRecordsInOrigin(String origin, long mTime){
         return performStorageAction("getAmountOfRecordsForOrigin(origin: " + origin +")", storage -> {
             validateOriginExists(origin);
-            return storage.getAmountOfRecordsForOrigin(origin);
+            return storage.getAmountOfRecordsForOrigin(origin, mTime);
         } );
     }
 

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -76,6 +76,8 @@ public class DsStorageFacade {
     /**
      * Get the count of records from a specific origin
      * @param origin to count amount of records from.
+     * @param mTime  is needed to deliver a number that is equal to the extracted values.
+     * @return the number of records sent through the stream.
      */
     public static long countRecordsInOrigin(String origin, long mTime){
         return performStorageAction("getAmountOfRecordsForOrigin(origin: " + origin +")", storage -> {

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -74,6 +74,17 @@ public class DsStorageFacade {
     }
 
     /**
+     * Get the count of records from a specific origin
+     * @param origin to count amount of records from.
+     */
+    public static long countRecordsInOrigin(String origin){
+        return performStorageAction("getAmountOfRecordsForOrigin(origin: " + origin +")", storage -> {
+            validateOriginExists(origin);
+            return storage.getAmountOfRecordsForOrigin(origin);
+        } );
+    }
+
+    /**
     *   Retrieve records (DsRecordDs) as a list. The local record tree will not be loaded as objects
     *
     *   @param origin origin for the record. Origins are defined in the yaml file

--- a/src/main/java/dk/kb/storage/storage/DsStorage.java
+++ b/src/main/java/dk/kb/storage/storage/DsStorage.java
@@ -159,7 +159,8 @@ public class DsStorage implements AutoCloseable {
 
     private static String originsStatisticsStatement = "SELECT " + ORIGIN_COLUMN + " ,COUNT(*) AS COUNT , SUM("+DELETED_COLUMN+") AS deleted,  max("+MTIME_COLUMN + ") AS MAX FROM " + RECORDS_TABLE + " group by " + ORIGIN_COLUMN;
     private static String deleteMarkedForDeleteStatement = "DELETE FROM " + RECORDS_TABLE + " WHERE "+ORIGIN_COLUMN +" = ? AND "+DELETED_COLUMN +" = 1" ;   
-    private static String recordIdExistsStatement = "SELECT COUNT(*) AS COUNT FROM " + RECORDS_TABLE+ " WHERE "+ID_COLUMN +" = ?";			
+    private static String recordIdExistsStatement = "SELECT COUNT(*) AS COUNT FROM " + RECORDS_TABLE+ " WHERE "+ID_COLUMN +" = ?";
+    private static String countRecordsInOriginStatement = "SELECT COUNT(*) FROM " + RECORDS_TABLE +  " WHERE " + ORIGIN_COLUMN + " = ?";
 
 
     private static BasicDataSource dataSource;
@@ -596,6 +597,26 @@ public class DsStorage implements AutoCloseable {
             }
         }
         return originCountList;
+    }
+
+    /**
+     * Get total amount of records for a specific {@link #ORIGIN_COLUMN}.
+     * @param origin the origin to query for in the database.
+     * @return the amount of records for the specified origin.
+     */
+    public Long getAmountOfRecordsForOrigin(String origin) throws SQLException {
+        long recordsInOrigin = 0L;
+        try (PreparedStatement statement = connection.prepareStatement(countRecordsInOriginStatement)){
+            statement.setString(1, origin);
+
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()){
+                    recordsInOrigin = rs.getLong(1);
+                }
+            }
+        }
+
+        return recordsInOrigin;
     }
 
     public void createNewRecord(DsRecordDto record) throws Exception {

--- a/src/main/java/dk/kb/storage/storage/DsStorage.java
+++ b/src/main/java/dk/kb/storage/storage/DsStorage.java
@@ -603,6 +603,7 @@ public class DsStorage implements AutoCloseable {
     /**
      * Get total amount of records for a specific {@link #ORIGIN_COLUMN}.
      * @param origin the origin to query for in the database.
+     * @param mTime  is needed to only deliver the values that are actually extracted.
      * @return the amount of records for the specified origin.
      */
     public Long getAmountOfRecordsForOrigin(String origin, Long mTime) throws SQLException {

--- a/src/main/java/dk/kb/storage/storage/DsStorage.java
+++ b/src/main/java/dk/kb/storage/storage/DsStorage.java
@@ -19,6 +19,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Objects;
 
 
 /*
@@ -160,7 +161,7 @@ public class DsStorage implements AutoCloseable {
     private static String originsStatisticsStatement = "SELECT " + ORIGIN_COLUMN + " ,COUNT(*) AS COUNT , SUM("+DELETED_COLUMN+") AS deleted,  max("+MTIME_COLUMN + ") AS MAX FROM " + RECORDS_TABLE + " group by " + ORIGIN_COLUMN;
     private static String deleteMarkedForDeleteStatement = "DELETE FROM " + RECORDS_TABLE + " WHERE "+ORIGIN_COLUMN +" = ? AND "+DELETED_COLUMN +" = 1" ;   
     private static String recordIdExistsStatement = "SELECT COUNT(*) AS COUNT FROM " + RECORDS_TABLE+ " WHERE "+ID_COLUMN +" = ?";
-    private static String countRecordsInOriginStatement = "SELECT COUNT(*) FROM " + RECORDS_TABLE +  " WHERE " + ORIGIN_COLUMN + " = ?";
+    private static String countRecordsInOriginStatement = "SELECT COUNT(*) FROM " + RECORDS_TABLE +  " WHERE " + ORIGIN_COLUMN + " = ? AND " + MTIME_COLUMN + " > ?";
 
 
     private static BasicDataSource dataSource;
@@ -604,10 +605,11 @@ public class DsStorage implements AutoCloseable {
      * @param origin the origin to query for in the database.
      * @return the amount of records for the specified origin.
      */
-    public Long getAmountOfRecordsForOrigin(String origin) throws SQLException {
+    public Long getAmountOfRecordsForOrigin(String origin, Long mTime) throws SQLException {
         long recordsInOrigin = 0L;
         try (PreparedStatement statement = connection.prepareStatement(countRecordsInOriginStatement)){
             statement.setString(1, origin);
+            statement.setLong(2, Objects.requireNonNullElse(mTime, 0L));
 
             try (ResultSet rs = statement.executeQuery()) {
                 if (rs.next()){

--- a/src/main/openapi/ds-storage-openapi_v1.yaml
+++ b/src/main/openapi/ds-storage-openapi_v1.yaml
@@ -50,28 +50,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/OriginCountList'
 
-  /origin/stats/single:
-    get:
-      tags:
-        - '${project.name}'
-      summary: 'Show amount of records in origin'
-      operationId: getSingleOriginStatistics
-      parameters:
-        - name: origin
-          in: query
-          schema:
-            type: string
-            example: ${example_origin}
-      responses:
-        '200':
-          description: 'Show how many records exists for each origin'
-          content:
-            text/plain:
-              schema:
-                type: integer
-                format: int64
-
-
   /origin/cleanup:
     delete:
       tags:

--- a/src/main/openapi/ds-storage-openapi_v1.yaml
+++ b/src/main/openapi/ds-storage-openapi_v1.yaml
@@ -50,6 +50,27 @@ paths:
               schema:
                 $ref: '#/components/schemas/OriginCountList'
 
+  /origin/stats/single:
+    get:
+      tags:
+        - '${project.name}'
+      summary: 'Show amount of records in origin'
+      operationId: getSingleOriginStatistics
+      parameters:
+        - name: origin
+          in: query
+          schema:
+            type: string
+            example: ${example_origin}
+      responses:
+        '200':
+          description: 'Show how many records exists for each origin'
+          content:
+            text/plain:
+              schema:
+                type: integer
+                format: int64
+
 
   /origin/cleanup:
     delete:


### PR DESCRIPTION
In #34 I added an intermediary ByteArrayStream. This is not scalable and how we are producing these endpoints. This PR removes that intermediary stream and gets the amount of records for the `Paging-Record-Count`-header by comparing the amount of records asked for and looking at how many records there are available in the database instead. 

Sorry for the double PR.