### PR TITLE
remove enum from origins in openAPI spec

### DIFF
--- a/src/main/openapi/ds-storage-openapi_v1.yaml
+++ b/src/main/openapi/ds-storage-openapi_v1.yaml
@@ -66,7 +66,7 @@ paths:
           required: true
           schema:
             type: string
-            enum: [${allowed_origins}]
+            example: ${example_origin}
       responses:
         '200':
           description: OK
@@ -93,7 +93,6 @@ paths:
           schema:
             type: string
             example: ${example_origin}
-            enum: [${allowed_origins}]
         - name: mTimeFrom
           in: query
           description: 'Format is milliseconds since Epoch with 3 added digits. Value is included in the deletion'
@@ -265,7 +264,6 @@ paths:
           schema:
             type: string
             example: ${example_origin}
-            enum: [${allowed_origins}]
         - name: recordType
           in: query
           description: 'Only extract records with this recordtype'
@@ -321,7 +319,6 @@ paths:
           schema:
             type: string
             example: ${example_origin}
-            enum: [${allowed_origins}]
         - name: mTime
           in: query
           description: >


### PR DESCRIPTION
One of three super small PRs removing enums from openAPI specs. 
To test run the service locally and see that origins can be written for the endpoints `/records`, `/origin/cleanup` and `recordsBy...`