### PR TITLE
Bugfix: Switch from Jersey to Apache URI Builder to handle parameters containing '{' 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## Changed
-Added two new fields to record: kalturareferenceid and kalturainternalid. The kaltura internal id is required by the frontend for thumbnails and streaming. 
-New service method to update the kalturaId for a record. Both create new record and update record will set the kalturareferenceid.
+- Added two new fields to record: kalturareferenceid and kalturainternalid. The kaltura internal id is required by the frontend for thumbnails and streaming. 
+- New service method to update the kalturaId for a record. Both create new record and update record will set the kalturareferenceid.
+
+### Fixed
+- Switch from Jersey to Apache URI Builder to handle parameters containing '{' [DRA-338](https://kb-dk.atlassian.net/browse/DRA-338)
 
 ## [1.18](https://github.com/kb-dk/ds-storage/releases/tag/ds-storage-1.18) 2024-03-08
 

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.4.24</version>
+            <version>1.5.2</version>
             <exclusions>
                 <exclusion>
                     <!-- kb-util has 2.3.3, but transitive resolving has 2.4.0 somewhere-->


### PR DESCRIPTION
Jersey's `UriBuilder` treats `{` as the signal for an expansion mechanism, making requests containing `{` fail. This pull request switches to Apache's `URIBuilder`.