### PR TITLE
Dra 397 update records with kalturaid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 - new table Mappings with fields (referenceId,kalturaId) and methods to create/update/read entries
-
+- new service method that will enrich records in the records table with kalturaid from the mapping table
 
 ### Fixed
 - Switch from Jersey to Apache URI Builder to handle parameters containing '{' [DRA-338](https://kb-dk.atlassian.net/browse/DRA-338)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## Changed
-- Added two new fields to record: kalturareferenceid and kalturainternalid. The kaltura internal id is required by the frontend for thumbnails and streaming. [DRA-314](https://kb-dk.atlassian.net/browse/DRA-314)  
-- New service method to update the kalturaId for a record. Both create new record and update record will set the kalturareferenceid. [DRA-314](https://kb-dk.atlassian.net/browse/DRA-314)
 - Support for dynamically updating values in OpenAPI spec. [DRA-139](https://kb-dk.atlassian.net/browse/DRA-139).
 
 ## Added
 - new table Mappings with fields (referenceId,kalturaId) and methods to create/update/read entries
 - new service method that will enrich records in the records table with kalturaid from the mapping table
+- New service method  (record/updateKalturaId) to update the kalturaId for a record. Both create new record and update record will set the kalturareferenceid. [DRA-314](https://kb-dk.atlassian.net/browse/DRA-314)
+- new service method (records/updateKalturaId) that updates kalturaId for all records that have referenceId and no Kaltura, given the mapping reference<-> KalturaId is found in mapping table.
+- Added two new fields to record: kalturareferenceid and kalturainternalid. The kaltura internal id is required by the frontend for thumbnails and streaming. [DRA-314](https://kb-dk.atlassian.net/browse/DRA-314)
+
 
 ### Fixed
 - Switch from Jersey to Apache URI Builder to handle parameters containing '{' [DRA-338](https://kb-dk.atlassian.net/browse/DRA-338)

--- a/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
+++ b/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
@@ -311,6 +311,10 @@ public class DsStorageApiServiceImpl extends ImplBase implements DsStorageApi {
             throw handleException(e);
         }        
     }
-  
+    @Override
+    public Integer updateKalturaIdForRecords() {
+        log.debug("updateKalturaIdForRecords() called with call details: {}", getCallDetails());
+        return DsStorageFacade.updateKalturaIdForRecords();        
+    }  
 
 }

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -128,7 +128,22 @@ public class DsStorageFacade {
         });
     }
     
-
+    
+    /**
+     * <p>
+     * Update all records that have referenceId but missing kalturaId.<br>
+     * If the mapping exist in the mapping table rerenceId <-> kalturaId, then the record will be updated with the kaltura.<br>
+     * If the mapping does not exist (yet), the record will not be updated with kaltura id.<br>
+     * <br>
+     * If many records needs to be updated this can take some time. 1M records is estimated to take 15 minutes. 
+     * </p>
+     *    
+     * @return Number of records that was enriched with kalturaId 
+     */
+    public static int updateKalturaIdForRecords() {
+       return performStorageAction("updateKalturaIdForRecords", DsStorage::updateKalturaIdForRecords);
+    }  
+    
     public static ArrayList<OriginCountDto> getOriginStatistics() {
         return performStorageAction("getOriginStatistics", DsStorage::getOriginStatictics);
     }

--- a/src/main/openapi/ds-storage-openapi_v1.yaml
+++ b/src/main/openapi/ds-storage-openapi_v1.yaml
@@ -307,6 +307,26 @@ paths:
 
 
 
+  /records/updateKalturaId:     
+    post:
+      tags:
+        - '${project.name}'    
+      summary: 'Update all records having a referenceIf with the matching Kaltura, if the mapping can be found in the mapping table'
+      description: >
+        Update all records having a referenceId with the matching kalturaId, if the mapping can be found in the mapping table. 
+        If many records needs to be updated this can take some time. Estimated 15 minutes for 1M records.
+        It is possible to update in batches if the mapping table is also updated in batches.                
+      operationId: updateKalturaIdForRecords
+          
+      responses:
+        '200':
+          description: The number of records that was enriched with kalturaId
+          content:
+            application/json:
+              schema:
+                type: integer
+                format: int32        
+
   /mapping:
     get:
       tags:

--- a/src/test/java/dk/kb/storage/storage/DsStorageTest.java
+++ b/src/test/java/dk/kb/storage/storage/DsStorageTest.java
@@ -217,7 +217,7 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
     * |id1|referenceid1|     (null) |        (This can be enriched with kalturaid)
     * |id1|referenceid2|     (null) |        (this record needs to be enriched, but referenceid2 is not in the mapping table) 
     * |id3|null        |     (null) |        (this record can not be enriched with kalturaid, no referenceId)
-    * |id4|referenceid4|(kalturaid4)|        (this is already as kalturaid)
+    * |id4|referenceid4|(kalturaid4)|        (this  already has kalturaid)
     * 
     * MAPPING table:
     * |REFERENCEID | KALTURAID|
@@ -225,7 +225,7 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
     * |referenceid1|kalturaid1|              (this mappen can be used to enrich record with id1)
     * |referenceid4|kalturaid4|              (no record that has referenceid4, so not used)
     *   
-    * This is the result of the SQL inner join, only one row is generated from about data structure
+    * This is the result of the SQL inner join, only one row is generated from data structure
     * 
     * JOIN-RESULT-SET
     * |ID| REFERENCEID | KALTURAID|

--- a/src/test/resources/ddl/create_ds_storage.ddl
+++ b/src/test/resources/ddl/create_ds_storage.ddl
@@ -28,6 +28,6 @@ CREATE INDEX rt ON ds_records(recordtype);
 CREATE INDEX om ON ds_records (origin, mtime);
 CREATE INDEX orm ON ds_records (origin, recordtype, mtime);
 CREATE INDEX kref ON ds_records (referenceid);
-
+CREATE INDEX kalid ON ds_records (kalturaid);
 
 CREATE UNIQUE INDEX mapping_i ON ds_mapping(refrenceid);

--- a/src/test/resources/ddl/create_ds_storage_h2_unittest.ddl
+++ b/src/test/resources/ddl/create_ds_storage_h2_unittest.ddl
@@ -29,5 +29,6 @@ CREATE INDEX IF NOT EXISTS rt ON ds_records(recordtype);
 CREATE INDEX IF NOT EXISTS om ON ds_records (origin, mtime);
 CREATE INDEX IF NOT EXISTS orm ON ds_records (origin, recordtype, mtime);
 CREATE INDEX IF NOT EXISTS kref ON ds_records (referenceid);
+CREATE INDEX IF NOT EXISTS kalid ON ds_records (kalturaid);
 
 CREATE UNIQUE INDEX IF NOT EXISTS mapping_i ON ds_mapping(referenceid);


### PR DESCRIPTION
1 new service method+facade method+storage method+sql

new method 'records/updateKalturaId' that will update all records that have referenceId but missing kalturaId, if the
kalturaId is found in the mapping table.