### PR TITLE
Dra 398 update record with fileref

### DIFF
--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -105,13 +105,15 @@ public class DsStorageFacade {
             if (recordExists) {
                 //Have to load record to see if referenceId has changed. Then we need to clear kalturaId
                 DsRecordDto oldRecord = storage.loadRecord(record.getId());
-                 
-                //If new record has a referenceId that does not match old one, clear the old kalturaId since it will be a new stream.
-                if (record.getKalturaId()== null && record.getReferenceId()  != null && !record.getReferenceId().equals(oldRecord.getReferenceId())) {
-                   System.out.println("clear kalturaId");
-                    record.setKalturaId(null); //Notice kalturaId is reset if input record has a kalturaId, but this is not in current scenario                     
-                }                
                 
+                System.out.println("new kal id:"+record.getKalturaId());
+                System.out.println("newRef:"+record.getReferenceId());
+                System.out.println("oldRef:"+oldRecord.getReferenceId());
+                
+                //Keep old kalturaId if referenceid is the same.
+                 if (record.getKalturaId() == null && record.getReferenceId() != null && !record.getReferenceId().equals(oldRecord.getReferenceId())) {                   
+                    record.setKalturaId(oldRecord.getKalturaId());                      
+                 }                                
                 log.info("Updating record with id:"+record.getId());
                 storage.updateRecord(record);
             } else {               

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -103,6 +103,14 @@ public class DsStorageFacade {
             
             boolean recordExists = storage.recordExists(record.getId());
             if (recordExists) {
+                //Have to load record to see if referenceId has changed. Then we need to clear kalturaId
+                DsRecordDto oldRecord = storage.loadRecord(record.getId());
+                 
+                //If new record has a referenceId that does not match old one, clear the old kalturaId since it will be a new stream.
+                if (record.getKalturaId()== null && record.getReferenceId()  != null && !record.getReferenceId().equals(oldRecord.getReferenceId())) {
+                    record.setKalturaId(null); //Notice kalturaId is reset if input record has a kalturaId, but this is not in current scenario                     
+                }                
+                
                 log.info("Updating record with id:"+record.getId());
                 storage.updateRecord(record);
             } else {               

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -105,11 +105,7 @@ public class DsStorageFacade {
             if (recordExists) {
                 //Have to load record to see if referenceId has changed. Then we need to clear kalturaId
                 DsRecordDto oldRecord = storage.loadRecord(record.getId());
-                
-                System.out.println("new kal id:"+record.getKalturaId());
-                System.out.println("newRef:"+record.getReferenceId());
-                System.out.println("oldRef:"+oldRecord.getReferenceId());
-                
+              
                 //Keep old kalturaId if referenceid is the same.
                  if (record.getKalturaId() == null && record.getReferenceId() != null && !record.getReferenceId().equals(oldRecord.getReferenceId())) {                   
                     record.setKalturaId(oldRecord.getKalturaId());                      

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -108,6 +108,7 @@ public class DsStorageFacade {
                  
                 //If new record has a referenceId that does not match old one, clear the old kalturaId since it will be a new stream.
                 if (record.getKalturaId()== null && record.getReferenceId()  != null && !record.getReferenceId().equals(oldRecord.getReferenceId())) {
+                   System.out.println("clear kalturaId");
                     record.setKalturaId(null); //Notice kalturaId is reset if input record has a kalturaId, but this is not in current scenario                     
                 }                
                 

--- a/src/main/java/dk/kb/storage/storage/DsStorage.java
+++ b/src/main/java/dk/kb/storage/storage/DsStorage.java
@@ -79,7 +79,8 @@ public class DsStorage implements AutoCloseable {
             DATA_COLUMN + " = ? , "+                         
             MTIME_COLUMN + " = ? , "+
             DELETED_COLUMN + " = 0 , "+
-            RECORDS_REFERENCE_ID_COLUMN + " = ? , "+             
+            RECORDS_REFERENCE_ID_COLUMN + " = ? , "+
+            RECORDS_KALTURA_ID_COLUMN + " = ? , "+
             PARENT_ID_COLUMN + " = ?  "+            
             "WHERE "+
             ID_COLUMN + "= ?";
@@ -937,8 +938,9 @@ public class DsStorage implements AutoCloseable {
             stmt.setString(2, record.getData());
             stmt.setLong(3, nowStamp);          
             stmt.setString(4, record.getReferenceId());
-            stmt.setString(5, record.getParentId());
-            stmt.setString(6, record.getId());
+            stmt.setString(5, record.getKalturaId());
+            stmt.setString(6, record.getParentId());            
+            stmt.setString(7, record.getId());
             stmt.executeUpdate();
         } catch (SQLException e) {
             String message = "SQL Exception in updateRecord with id:" + record.getId() + " error:" + e.getMessage();

--- a/src/test/java/dk/kb/storage/facade/DsStorageFacadeTest.java
+++ b/src/test/java/dk/kb/storage/facade/DsStorageFacadeTest.java
@@ -103,14 +103,13 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
 
     
     @Test
-    public void testClearKalturaId() throws Exception {
+    public void testKeepKalturaId() throws Exception {
         String id ="doms.radio:id1";
         String origin="doms.radio";
         String data = "Hello";       
         String referenceId="referenceId_123";
         String referenceIdUpdated="referenceId_123_updated";
-        String kalturaId="kalturaId";
-        RecordTypeDto recordType=RecordTypeDto.MANIFESTATION;
+        String kalturaId="kalturaId";        
         
         DsRecordDto record = new DsRecordDto();
         record.setId(id);
@@ -129,12 +128,10 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
 
         //New update record, but the new record does not have kalturaId, but has a difference referenceId
         record.setReferenceId(referenceIdUpdated);        
+        record.setKalturaId(null); //blank, but updated post will still have old value
         DsStorageFacade.createOrUpdateRecord(record);        
         DsRecordDto updatedRecord=DsStorageFacade.getRecordTree(id);
-        //Test kalturaId is reset
-        System.out.println(updatedRecord.getKalturaId());
-        assertNull(updatedRecord.getKalturaId());
-            
+        assertEquals(kalturaId,updatedRecord.getKalturaId());            
     }
     
     @Test

--- a/src/test/java/dk/kb/storage/facade/DsStorageFacadeTest.java
+++ b/src/test/java/dk/kb/storage/facade/DsStorageFacadeTest.java
@@ -101,6 +101,42 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
 
     }
 
+    
+    @Test
+    public void testClearKalturaId() throws Exception {
+        String id ="doms.radio:id1";
+        String origin="doms.radio";
+        String data = "Hello";       
+        String referenceId="referenceId_123";
+        String referenceIdUpdated="referenceId_123_updated";
+        String kalturaId="kalturaId";
+        RecordTypeDto recordType=RecordTypeDto.MANIFESTATION;
+        
+        DsRecordDto record = new DsRecordDto();
+        record.setId(id);
+        record.setOrigin(origin);
+        record.setData(data);
+
+        record.setRecordType(RecordTypeDto.MANIFESTATION);
+        record.setReferenceId(referenceId);
+        record.setKalturaId(kalturaId);
+        DsStorageFacade.createOrUpdateRecord(record);
+        
+        //See referenceId and kalturaId is set correct
+        DsRecordDto newCreatedRecord=DsStorageFacade.getRecordTree(id);
+        assertEquals(referenceId,newCreatedRecord.getReferenceId());
+        assertEquals(kalturaId,newCreatedRecord.getKalturaId());
+
+        //New update record, but the new record does not have kalturaId, but has a difference referenceId
+        record.setReferenceId(referenceIdUpdated);        
+        DsStorageFacade.createOrUpdateRecord(record);        
+        DsRecordDto updatedRecord=DsStorageFacade.getRecordTree(id);
+        //Test kalturaId is reset
+        System.out.println(updatedRecord.getKalturaId());
+        assertNull(updatedRecord.getKalturaId());
+            
+    }
+    
     @Test
     public void testUnknownOrigin() throws Exception {
         String id ="unkown.origin:id1";

--- a/src/test/java/dk/kb/storage/storage/DsStorageTest.java
+++ b/src/test/java/dk/kb/storage/storage/DsStorageTest.java
@@ -121,41 +121,6 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
 
     
     @Test
-    public void testClearKalturaId() throws Exception {
-        String id ="origin.test:id1";
-        String origin="origin.test";
-        String data = "Hello";
-        String parentId="origin.test:id_1_parent";
-        String referenceId="referenceId_123";
-        String referenceIdUpdated="referenceId_123_updated";
-        String kalturaId="kalturaId";
-        RecordTypeDto recordType=RecordTypeDto.MANIFESTATION;
-        
-        DsRecordDto record = new DsRecordDto();
-        record.setId(id);
-        record.setOrigin(origin);
-        record.setData(data);
-        record.setParentId(parentId);
-        record.setRecordType(RecordTypeDto.MANIFESTATION);
-        record.setReferenceId(referenceId);
-        record.setKalturaId(kalturaId);
-        storage.createNewRecord(record );
-        
-        //See referenceId and kalturaId is set correct
-        DsRecordDto newCreatedRecord=storage.loadRecord(id);
-        assertEquals(referenceId,newCreatedRecord.getReferenceId());
-        assertEquals(kalturaId,newCreatedRecord.getKalturaId());
-
-        //New update record, but the new record does not have kalturaId, but has a difference referenceId
-        record.setReferenceId(referenceIdUpdated);        
-        storage.updateRecord(record);        
-        DsRecordDto updatedRecord=storage.loadRecord(id);
-        //Test kalturaId is reset
-        assertNull(updatedRecord.getKalturaId());
-            
-    }
-    
-    @Test
     public void testMappingCRUD() throws Exception {
         
         //Create with both ids

--- a/src/test/java/dk/kb/storage/storage/DsStorageTest.java
+++ b/src/test/java/dk/kb/storage/storage/DsStorageTest.java
@@ -119,6 +119,42 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         Assertions.assertNull(deletedReally);
     }
 
+    
+    @Test
+    public void testClearKalturaId() throws Exception {
+        String id ="origin.test:id1";
+        String origin="origin.test";
+        String data = "Hello";
+        String parentId="origin.test:id_1_parent";
+        String referenceId="referenceId_123";
+        String referenceIdUpdated="referenceId_123_updated";
+        String kalturaId="kalturaId";
+        RecordTypeDto recordType=RecordTypeDto.MANIFESTATION;
+        
+        DsRecordDto record = new DsRecordDto();
+        record.setId(id);
+        record.setOrigin(origin);
+        record.setData(data);
+        record.setParentId(parentId);
+        record.setRecordType(RecordTypeDto.MANIFESTATION);
+        record.setReferenceId(referenceId);
+        record.setKalturaId(kalturaId);
+        storage.createNewRecord(record );
+        
+        //See referenceId and kalturaId is set correct
+        DsRecordDto newCreatedRecord=storage.loadRecord(id);
+        assertEquals(referenceId,newCreatedRecord.getReferenceId());
+        assertEquals(kalturaId,newCreatedRecord.getKalturaId());
+
+        //New update record, but the new record does not have kalturaId, but has a difference referenceId
+        record.setReferenceId(referenceIdUpdated);        
+        storage.updateRecord(record);        
+        DsRecordDto updatedRecord=storage.loadRecord(id);
+        //Test kalturaId is reset
+        assertNull(updatedRecord.getKalturaId());
+            
+    }
+    
     @Test
     public void testMappingCRUD() throws Exception {
         


### PR DESCRIPTION
New logic:
When  creating a record it is possible to give both fileReference and kalturaId as part of record. However it is not likely
that kalturaId is known as this time, but it is possible to give it a value.

New update logic:
If a record is updated with same fileReference, the kalturaId will not be cleared. 
If a record is updated with a new fileReferencde, the kalturId will be clearned (unless give also as part of reocrd).