### PR TITLE
Dra 517 extract referenceids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Added
+- Added new API method (/record/referenceids) to extract records with a minimum of fields. Is used to enrich kalturaid data from referenceId
 
+
+
+## [1.19](https://github.com/kb-dk/ds-storage/releases/tag/ds-storage-1.19) 2024-05-28
 
 ### Changed
 
@@ -19,12 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New service method  (record/updateKalturaId) to update the kalturaId for a record. Both create new record and update record will set the kalturareferenceid. [DRA-314](https://kb-dk.atlassian.net/browse/DRA-314)
 - new service method (records/updateKalturaId) that updates kalturaId for all records that have referenceId and no Kaltura, given the mapping reference<-> KalturaId is found in mapping table.
 - Added two new fields to record: kalturareferenceid and kalturainternalid. The kaltura internal id is required by the frontend for thumbnails and streaming. [DRA-314](https://kb-dk.atlassian.net/browse/DRA-314)
-- Added new API method (/record/referenceids) to extract records with a minimum of fields. Is used to enrich kalturaid data from referenceId
-
 
 ### Fixed
 - Switch from Jersey to Apache URI Builder to handle parameters containing '{' [DRA-338](https://kb-dk.atlassian.net/browse/DRA-338)
 - Correct resolving of maven build time in project properties. [DRA-417](https://kb-dk.atlassian.net/browse/DRA-417)
+
+
 
 ## [1.18](https://github.com/kb-dk/ds-storage/releases/tag/ds-storage-1.18) 2024-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New service method  (record/updateKalturaId) to update the kalturaId for a record. Both create new record and update record will set the kalturareferenceid. [DRA-314](https://kb-dk.atlassian.net/browse/DRA-314)
 - new service method (records/updateKalturaId) that updates kalturaId for all records that have referenceId and no Kaltura, given the mapping reference<-> KalturaId is found in mapping table.
 - Added two new fields to record: kalturareferenceid and kalturainternalid. The kaltura internal id is required by the frontend for thumbnails and streaming. [DRA-314](https://kb-dk.atlassian.net/browse/DRA-314)
+- Added new API method (/record/referenceids) to extract records with a minimum of fields. Is used to enrich kalturaid data from referenceId
 
 
 ### Fixed

--- a/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
+++ b/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
@@ -319,6 +319,19 @@ public class DsStorageApiServiceImpl extends ImplBase implements DsStorageApi {
     }
     
         
+    
+    /**
+    * <p>
+    * Get a list of records after a given mTime. The records will only have fields
+    * id,mTime,referenceid and kalturaid defined 
+    * </p>
+    *
+    * @param origin The origin to fetch records drom    
+    * @param batchSize Number of maximum records to return
+    * @param mTime only fetch records with mTime larger that this
+    *
+    * @return List of records only have fields id,mTime,referenceid and kalturaid
+    */
     @Override
     public List<DsRecordReferenceIdDto> referenceIds(String origin, Integer batchsize, Long mTime) {    
         log.debug("referenceIds called with call details: {}", getCallDetails());

--- a/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
+++ b/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
@@ -318,10 +318,12 @@ public class DsStorageApiServiceImpl extends ImplBase implements DsStorageApi {
         return DsStorageFacade.updateKalturaIdForRecords();        
     }
     
+        
     @Override
-    public DsRecordReferenceIdDto referenceIds(String origin, Integer batchsize, Long mTime) {
-        // TODO Auto-generated method stub
-        return null;
-    }  
+    public List<DsRecordReferenceIdDto> referenceIds(String origin, Integer batchsize, Long mTime) {    
+        log.debug("referenceIds called with call details: {}", getCallDetails());
+        return DsStorageFacade.getReferenceIds(origin,mTime,batchsize);
+    }
+    
 
 }

--- a/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
+++ b/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
@@ -4,6 +4,7 @@ import dk.kb.storage.api.v1.DsStorageApi;
 import dk.kb.storage.config.ServiceConfig;
 import dk.kb.storage.facade.DsStorageFacade;
 import dk.kb.storage.model.v1.DsRecordDto;
+import dk.kb.storage.model.v1.DsRecordReferenceIdDto;
 import dk.kb.storage.model.v1.MappingDto;
 import dk.kb.storage.model.v1.OriginCountDto;
 import dk.kb.storage.model.v1.OriginDto;
@@ -315,6 +316,12 @@ public class DsStorageApiServiceImpl extends ImplBase implements DsStorageApi {
     public Integer updateKalturaIdForRecords() {
         log.debug("updateKalturaIdForRecords() called with call details: {}", getCallDetails());
         return DsStorageFacade.updateKalturaIdForRecords();        
+    }
+    
+    @Override
+    public DsRecordReferenceIdDto referenceIds(String origin, Integer batchsize, Long mTime) {
+        // TODO Auto-generated method stub
+        return null;
     }  
 
 }

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -105,13 +105,15 @@ public class DsStorageFacade {
             if (recordExists) {
                 //Have to load record to see if referenceId has changed. Then we need to clear kalturaId
                 DsRecordDto oldRecord = storage.loadRecord(record.getId());
-                 
-                //If new record has a referenceId that does not match old one, clear the old kalturaId since it will be a new stream.
-                if (record.getKalturaId()== null && record.getReferenceId()  != null && !record.getReferenceId().equals(oldRecord.getReferenceId())) {
-                   System.out.println("clear kalturaId");
-                    record.setKalturaId(null); //Notice kalturaId is reset if input record has a kalturaId, but this is not in current scenario                     
-                }                
                 
+                System.out.println("new kal id:"+record.getKalturaId());
+                System.out.println("newRef:"+record.getReferenceId());
+                System.out.println("oldRef:"+oldRecord.getReferenceId());
+                
+                //Keep old kalturaId if referenceid is the same.
+                 if (record.getKalturaId() == null && record.getReferenceId() != null && !record.getReferenceId().equals(oldRecord.getReferenceId())) {                   
+                    record.setKalturaId(oldRecord.getKalturaId());                      
+                 }                                
                 log.info("Updating record with id:"+record.getId());
                 storage.updateRecord(record);
             } else {               

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import dk.kb.storage.config.ServiceConfig;
 import dk.kb.storage.model.v1.DsRecordDto;
+import dk.kb.storage.model.v1.DsRecordReferenceIdDto;
 import dk.kb.storage.model.v1.MappingDto;
 import dk.kb.storage.model.v1.OriginCountDto;
 import dk.kb.storage.model.v1.OriginDto;
@@ -31,6 +32,27 @@ import dk.kb.util.webservice.exception.NotFoundServiceException;
 public class DsStorageFacade {
 
     private static final Logger log = LoggerFactory.getLogger(DsStorageFacade.class);
+
+
+    /**
+     * <p>
+     * Get a list of records after a given mTime. The records will only have fields
+     * id,mTime,referenceid and kalturaid defined 
+     * </p>
+     *
+     *@param origin The origin to fetch records drom
+     *@param mTime only fetch records with mTime larger that this
+     *@param batchSize Number of maximum records to return
+     *
+     * @return List of records only have fields id,mTime,referenceid and kalturaid
+     */
+    public static  ArrayList<DsRecordReferenceIdDto>  getReferenceIds(String origin, long mTime, int batchSize)  {                       
+        String id = String.format(Locale.ROOT, "getReferenceIdr(origin='%s', mTime=%d, batchSize=%d)", origin, mTime, batchSize);
+        return performStorageAction(id, storage -> {             
+            return storage.getReferenceIds(origin, mTime, batchSize);   
+        });
+    }    
+    
 
     
     /**

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -47,7 +47,7 @@ public class DsStorageFacade {
      * @return List of records only have fields id,mTime,referenceid and kalturaid
      */
     public static  ArrayList<DsRecordReferenceIdDto>  getReferenceIds(String origin, long mTime, int batchSize)  {                       
-        String id = String.format(Locale.ROOT, "getReferenceIdr(origin='%s', mTime=%d, batchSize=%d)", origin, mTime, batchSize);
+        String id = String.format(Locale.ROOT, "getReferenceIds(origin='%s', mTime=%d, batchSize=%d)", origin, mTime, batchSize);
         return performStorageAction(id, storage -> {             
             return storage.getReferenceIds(origin, mTime, batchSize);   
         });

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -103,6 +103,14 @@ public class DsStorageFacade {
             
             boolean recordExists = storage.recordExists(record.getId());
             if (recordExists) {
+                //Have to load record to see if referenceId has changed. Then we need to clear kalturaId
+                DsRecordDto oldRecord = storage.loadRecord(record.getId());
+                 
+                //If new record has a referenceId that does not match old one, clear the old kalturaId since it will be a new stream.
+                if (record.getKalturaId()== null && record.getReferenceId()  != null && !record.getReferenceId().equals(oldRecord.getReferenceId())) {
+                    record.setKalturaId(null); //Notice kalturaId is reset if input record has a kalturaId, but this is not in current scenario                     
+                }                
+                
                 log.info("Updating record with id:"+record.getId());
                 storage.updateRecord(record);
             } else {               

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -105,11 +105,7 @@ public class DsStorageFacade {
             if (recordExists) {
                 //Have to load record to see if referenceId has changed. Then we need to clear kalturaId
                 DsRecordDto oldRecord = storage.loadRecord(record.getId());
-                
-                System.out.println("new kal id:"+record.getKalturaId());
-                System.out.println("newRef:"+record.getReferenceId());
-                System.out.println("oldRef:"+oldRecord.getReferenceId());
-                
+              
                 //Keep old kalturaId if referenceid is the same.
                  if (record.getKalturaId() == null && record.getReferenceId() != null && !record.getReferenceId().equals(oldRecord.getReferenceId())) {                   
                     record.setKalturaId(oldRecord.getKalturaId());                      

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -108,6 +108,7 @@ public class DsStorageFacade {
                  
                 //If new record has a referenceId that does not match old one, clear the old kalturaId since it will be a new stream.
                 if (record.getKalturaId()== null && record.getReferenceId()  != null && !record.getReferenceId().equals(oldRecord.getReferenceId())) {
+                   System.out.println("clear kalturaId");
                     record.setKalturaId(null); //Notice kalturaId is reset if input record has a kalturaId, but this is not in current scenario                     
                 }                
                 

--- a/src/main/java/dk/kb/storage/storage/DsStorage.java
+++ b/src/main/java/dk/kb/storage/storage/DsStorage.java
@@ -79,7 +79,8 @@ public class DsStorage implements AutoCloseable {
             DATA_COLUMN + " = ? , "+                         
             MTIME_COLUMN + " = ? , "+
             DELETED_COLUMN + " = 0 , "+
-            RECORDS_REFERENCE_ID_COLUMN + " = ? , "+             
+            RECORDS_REFERENCE_ID_COLUMN + " = ? , "+
+            RECORDS_KALTURA_ID_COLUMN + " = ? , "+
             PARENT_ID_COLUMN + " = ?  "+            
             "WHERE "+
             ID_COLUMN + "= ?";
@@ -937,8 +938,9 @@ public class DsStorage implements AutoCloseable {
             stmt.setString(2, record.getData());
             stmt.setLong(3, nowStamp);          
             stmt.setString(4, record.getReferenceId());
-            stmt.setString(5, record.getParentId());
-            stmt.setString(6, record.getId());
+            stmt.setString(5, record.getKalturaId());
+            stmt.setString(6, record.getParentId());            
+            stmt.setString(7, record.getId());
             stmt.executeUpdate();
         } catch (SQLException e) {
             String message = "SQL Exception in updateRecord with id:" + record.getId() + " error:" + e.getMessage();

--- a/src/main/java/dk/kb/storage/storage/DsStorage.java
+++ b/src/main/java/dk/kb/storage/storage/DsStorage.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import dk.kb.storage.model.v1.DsRecordDto;
+import dk.kb.storage.model.v1.DsRecordReferenceIdDto;
 import dk.kb.storage.model.v1.MappingDto;
 import dk.kb.storage.model.v1.OriginCountDto;
 import dk.kb.storage.model.v1.RecordTypeDto;
@@ -129,6 +130,21 @@ public class DsStorage implements AutoCloseable {
             " AND " + RECORDTYPE_COLUMN + "= ?" +
             " ORDER BY " + MTIME_COLUMN + " DESC";
 
+    
+    //SELECT id,mTime,referenceId,kalturaId FROM ds_records WHERE origin= 'ds.tv' and mTime > 0 ORDER BY mtime ASC LIMIT 50
+    private static final String referenceIdsStatement =
+            "SELECT " + MTIME_COLUMN + ", "
+                      + ID_COLUMN +","
+                      + MTIME_COLUMN+ " ,"
+                      + RECORDS_REFERENCE_ID_COLUMN +" ,"
+                      + RECORDS_KALTURA_ID_COLUMN                      
+                    + " FROM " + RECORDS_TABLE +
+            " WHERE " + ORIGIN_COLUMN + "= ?" +
+            " AND " + MTIME_COLUMN +" > ?" +
+            " ORDER BY " + MTIME_COLUMN + " ASC" +
+            " LIMIT ?";
+     
+    
     // TODO: Optimise this
     // The current implementation creates a temporary table
     // Alternative 1: Make a plain select and step through to the end
@@ -365,6 +381,46 @@ public class DsStorage implements AutoCloseable {
         return records; 
     }
 
+    
+
+    /**
+     * <p>
+     * Get a list of records after a given mTime. The records will only have fields
+     * id,mTime,referenceid and kalturaid defined 
+     * </p>
+     *
+     *@param origin The origin to fetch records drom
+     *@param mTime only fetch records with mTime larger that this
+     *@param batchSize Number of maximum records to return
+     *
+     * @return List of records only have fields id,mTime,referenceid and kalturaid
+     */
+    public ArrayList<DsRecordReferenceIdDto> getReferenceIds(String origin, long mTime, int batchSize) throws Exception {
+
+        if (batchSize <1 || batchSize > 100000) { //No doom switch
+            throw new Exception("Batchsize must be in range 1 to 100000");          
+        }
+        ArrayList<DsRecordReferenceIdDto> records = new ArrayList<DsRecordReferenceIdDto>();
+        try (PreparedStatement stmt = connection.prepareStatement(referenceIdsStatement)) {
+
+            stmt.setString(1, origin);
+            stmt.setLong(2, mTime);
+            stmt.setLong(3, batchSize);
+                        
+            try (ResultSet rs = stmt.executeQuery();) {
+                while (rs.next()) {
+                    DsRecordReferenceIdDto  record = createRecordReferenceIdFromRS(rs);
+                    records.add(record);
+                }
+            }
+        }
+        catch(Exception e) {
+            throw new Exception("SQL error getReferenceIds",e);
+        }
+
+        return records; 
+    }
+    
     /**
      * Extract max {@code record.mTime} in {@code origin}.
      * @param origin only records from the {@code origin} will be inspected.
@@ -1018,11 +1074,26 @@ public class DsStorage implements AutoCloseable {
         return record;
     }
 
+    
+    private static DsRecordReferenceIdDto createRecordReferenceIdFromRS(ResultSet rs) throws SQLException {
+        String id = rs.getString(ID_COLUMN);                              
+        long mTime = rs.getLong(MTIME_COLUMN);
+        String referenceId = rs.getString(RECORDS_REFERENCE_ID_COLUMN);
+        String kalturaId = rs.getString(RECORDS_KALTURA_ID_COLUMN);
+        
+        DsRecordReferenceIdDto record = new DsRecordReferenceIdDto();
+        record.setId(id);                        
+        record.setmTime(mTime);        
+        record.setReferenceId(referenceId);
+        record.setKalturaId(kalturaId);        
+        return record;
+    }
+
+    
     private static int boolToInt(Boolean isTrue) {
         if (isTrue == null) {
             return 0;
         }
-
         return isTrue ? 1 : 0;
     }
     

--- a/src/main/java/dk/kb/storage/storage/DsStorage.java
+++ b/src/main/java/dk/kb/storage/storage/DsStorage.java
@@ -389,16 +389,16 @@ public class DsStorage implements AutoCloseable {
      * id,mTime,referenceid and kalturaid defined 
      * </p>
      *
-     *@param origin The origin to fetch records drom
+     *@param origin The origin to fetch records from
      *@param mTime only fetch records with mTime larger that this
      *@param batchSize Number of maximum records to return
      *
      * @return List of records only have fields id,mTime,referenceid and kalturaid
      */
-    public ArrayList<DsRecordReferenceIdDto> getReferenceIds(String origin, long mTime, int batchSize) throws Exception {
+    public ArrayList<DsRecordReferenceIdDto> getReferenceIds(String origin, long mTime, int batchSize) throws SQLException {
 
         if (batchSize <1 || batchSize > 100000) { //No doom switch
-            throw new Exception("Batchsize must be in range 1 to 100000");          
+            throw new InvalidArgumentServiceException("Batchsize must be in range 1 to 100000");          
         }
         ArrayList<DsRecordReferenceIdDto> records = new ArrayList<DsRecordReferenceIdDto>();
         try (PreparedStatement stmt = connection.prepareStatement(referenceIdsStatement)) {
@@ -415,7 +415,7 @@ public class DsStorage implements AutoCloseable {
             }
         }
         catch(Exception e) {
-            throw new Exception("SQL error getReferenceIds",e);
+            throw new SQLException("SQL error getReferenceIds",e);
         }
 
         return records; 

--- a/src/main/openapi/ds-storage-openapi_v1.yaml
+++ b/src/main/openapi/ds-storage-openapi_v1.yaml
@@ -156,6 +156,50 @@ paths:
                 DSRecord:
                   $ref: '#/components/examples/GetDSRecord'
 
+  /record/referenceids:
+    get:
+      tags:
+        - '${project.name}'
+      summary: 'Get a list of records having a referenceId after a given lastModified time'
+      description: >
+       Extract a list of records with a given batch size by origin and mTime larger than input.        
+        The records will only has the id,mTime,referenceId and kalturaId fields set.       
+      operationId: referenceIds
+      parameters:
+        - name: origin
+          in: query
+          description: 'The origin to extract records for'
+          required: true
+          schema:
+            type: string
+            example: "ds.tv"
+        - name: mTime
+          in: query
+          description: 'Only extract records after this mTime.'
+          required: false
+          schema:
+            type: integer
+            format: int64
+            example: 1701262548465000
+            default: 0
+        - name: batchsize
+          in: query
+          description: 'Number of records to extract.'
+          required: true
+          schema:
+            type: integer            
+            example: 500
+            default: 500
+     
+      responses:
+        '200':
+          description: 'The DsRecord'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DsRecordReferenceId'        
+
+
     delete:
       tags:
         - '${project.name}'
@@ -501,6 +545,28 @@ components:
           type: string
           description: 'The Kaltura  ID for the record. It can be null even if the record is Kaltura but the mapping has not been updated yet.  '
                                                         
+    DsRecordReferenceId:
+      type: object
+      required:
+        - id
+        - origin
+        - recordType
+      properties:
+        id:
+          type: string
+          description: 'Unique identifier for the record. Id must start with the origin followed by : See module description for more about ID naming convention'
+        mTime:
+          type: integer
+          format: int64
+          description: 'Modification time for last create or update of the record. Format is milliseconds since Epoch with 3 added digits . When a record is updated, mTime for parent and child records can also be updated due to updatestrategy defined for that origin.'
+        referenceId:
+          type: string
+          description: 'The referenceId given when uploading the record to Kaltura. This field is only used for records that has a file associated intended streaming.'
+        kalturaId:
+          type: string
+          description: 'The Kaltura  ID for the record. It can be null even if the record is Kaltura but the mapping has not been updated yet.  '
+
+
 
     Mapping:
       type: object

--- a/src/main/openapi/ds-storage-openapi_v1.yaml
+++ b/src/main/openapi/ds-storage-openapi_v1.yaml
@@ -117,6 +117,51 @@ paths:
                 type: integer
                 format: int32
 
+
+  /record/referenceids:
+    get:
+      tags:
+        - '${project.name}'
+      summary: 'Get a list of records having a referenceId after a given lastModified time'
+      description: >
+       Extract a list of records with a given batch size by origin and mTime larger than input.        
+        The records will only has the id,mTime,referenceId and kalturaId fields set.       
+      operationId: referenceIds
+      parameters:
+        - name: origin
+          in: query
+          description: 'The origin to extract records for'
+          required: true
+          schema:
+            type: string
+            example: "ds.tv"
+        - name: mTime
+          in: query
+          description: 'Only extract records after this mTime.'
+          required: false
+          schema:
+            type: integer
+            format: int64
+            example: 1701262548465000
+            default: 0
+        - name: batchsize
+          in: query
+          description: 'Number of records to extract.'
+          required: true
+          schema:
+            type: integer            
+            example: 500
+            default: 500
+     
+      responses:
+        '200':
+          description: 'List of DsRecordReferenceId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DsRecordReferenceIdList'        
+
+
   /record/{id}:
     get:
       tags:
@@ -156,50 +201,7 @@ paths:
                 DSRecord:
                   $ref: '#/components/examples/GetDSRecord'
 
-  /record/referenceids:
-    get:
-      tags:
-        - '${project.name}'
-      summary: 'Get a list of records having a referenceId after a given lastModified time'
-      description: >
-       Extract a list of records with a given batch size by origin and mTime larger than input.        
-        The records will only has the id,mTime,referenceId and kalturaId fields set.       
-      operationId: referenceIds
-      parameters:
-        - name: origin
-          in: query
-          description: 'The origin to extract records for'
-          required: true
-          schema:
-            type: string
-            example: "ds.tv"
-        - name: mTime
-          in: query
-          description: 'Only extract records after this mTime.'
-          required: false
-          schema:
-            type: integer
-            format: int64
-            example: 1701262548465000
-            default: 0
-        - name: batchsize
-          in: query
-          description: 'Number of records to extract.'
-          required: true
-          schema:
-            type: integer            
-            example: 500
-            default: 500
-     
-      responses:
-        '200':
-          description: 'The DsRecord'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DsRecordReferenceId'        
-
-
+  
     delete:
       tags:
         - '${project.name}'
@@ -585,6 +587,13 @@ components:
       type: array
       items: 
         $ref: '#/components/schemas/DsRecord'
+
+    DsRecordReferenceIdList:
+      type: array
+      items: 
+        $ref: '#/components/schemas/DsRecordReferenceId'
+
+
 
     OriginList:
       type: array

--- a/src/test/java/dk/kb/storage/facade/DsStorageFacadeTest.java
+++ b/src/test/java/dk/kb/storage/facade/DsStorageFacadeTest.java
@@ -103,14 +103,13 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
 
     
     @Test
-    public void testClearKalturaId() throws Exception {
+    public void testKeepKalturaId() throws Exception {
         String id ="doms.radio:id1";
         String origin="doms.radio";
         String data = "Hello";       
         String referenceId="referenceId_123";
         String referenceIdUpdated="referenceId_123_updated";
-        String kalturaId="kalturaId";
-        RecordTypeDto recordType=RecordTypeDto.MANIFESTATION;
+        String kalturaId="kalturaId";        
         
         DsRecordDto record = new DsRecordDto();
         record.setId(id);
@@ -129,12 +128,10 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
 
         //New update record, but the new record does not have kalturaId, but has a difference referenceId
         record.setReferenceId(referenceIdUpdated);        
+        record.setKalturaId(null); //blank, but updated post will still have old value
         DsStorageFacade.createOrUpdateRecord(record);        
         DsRecordDto updatedRecord=DsStorageFacade.getRecordTree(id);
-        //Test kalturaId is reset
-        System.out.println(updatedRecord.getKalturaId());
-        assertNull(updatedRecord.getKalturaId());
-            
+        assertEquals(kalturaId,updatedRecord.getKalturaId());            
     }
     
     @Test

--- a/src/test/java/dk/kb/storage/facade/DsStorageFacadeTest.java
+++ b/src/test/java/dk/kb/storage/facade/DsStorageFacadeTest.java
@@ -101,6 +101,42 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
 
     }
 
+    
+    @Test
+    public void testClearKalturaId() throws Exception {
+        String id ="doms.radio:id1";
+        String origin="doms.radio";
+        String data = "Hello";       
+        String referenceId="referenceId_123";
+        String referenceIdUpdated="referenceId_123_updated";
+        String kalturaId="kalturaId";
+        RecordTypeDto recordType=RecordTypeDto.MANIFESTATION;
+        
+        DsRecordDto record = new DsRecordDto();
+        record.setId(id);
+        record.setOrigin(origin);
+        record.setData(data);
+
+        record.setRecordType(RecordTypeDto.MANIFESTATION);
+        record.setReferenceId(referenceId);
+        record.setKalturaId(kalturaId);
+        DsStorageFacade.createOrUpdateRecord(record);
+        
+        //See referenceId and kalturaId is set correct
+        DsRecordDto newCreatedRecord=DsStorageFacade.getRecordTree(id);
+        assertEquals(referenceId,newCreatedRecord.getReferenceId());
+        assertEquals(kalturaId,newCreatedRecord.getKalturaId());
+
+        //New update record, but the new record does not have kalturaId, but has a difference referenceId
+        record.setReferenceId(referenceIdUpdated);        
+        DsStorageFacade.createOrUpdateRecord(record);        
+        DsRecordDto updatedRecord=DsStorageFacade.getRecordTree(id);
+        //Test kalturaId is reset
+        System.out.println(updatedRecord.getKalturaId());
+        assertNull(updatedRecord.getKalturaId());
+            
+    }
+    
     @Test
     public void testUnknownOrigin() throws Exception {
         String id ="unkown.origin:id1";

--- a/src/test/java/dk/kb/storage/storage/DsStorageTest.java
+++ b/src/test/java/dk/kb/storage/storage/DsStorageTest.java
@@ -121,41 +121,6 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
 
     
     @Test
-    public void testClearKalturaId() throws Exception {
-        String id ="origin.test:id1";
-        String origin="origin.test";
-        String data = "Hello";
-        String parentId="origin.test:id_1_parent";
-        String referenceId="referenceId_123";
-        String referenceIdUpdated="referenceId_123_updated";
-        String kalturaId="kalturaId";
-        RecordTypeDto recordType=RecordTypeDto.MANIFESTATION;
-        
-        DsRecordDto record = new DsRecordDto();
-        record.setId(id);
-        record.setOrigin(origin);
-        record.setData(data);
-        record.setParentId(parentId);
-        record.setRecordType(RecordTypeDto.MANIFESTATION);
-        record.setReferenceId(referenceId);
-        record.setKalturaId(kalturaId);
-        storage.createNewRecord(record );
-        
-        //See referenceId and kalturaId is set correct
-        DsRecordDto newCreatedRecord=storage.loadRecord(id);
-        assertEquals(referenceId,newCreatedRecord.getReferenceId());
-        assertEquals(kalturaId,newCreatedRecord.getKalturaId());
-
-        //New update record, but the new record does not have kalturaId, but has a difference referenceId
-        record.setReferenceId(referenceIdUpdated);        
-        storage.updateRecord(record);        
-        DsRecordDto updatedRecord=storage.loadRecord(id);
-        //Test kalturaId is reset
-        assertNull(updatedRecord.getKalturaId());
-            
-    }
-    
-    @Test
     public void testMappingCRUD() throws Exception {
         
         //Create with both ids

--- a/src/test/java/dk/kb/storage/storage/DsStorageTest.java
+++ b/src/test/java/dk/kb/storage/storage/DsStorageTest.java
@@ -119,6 +119,42 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         Assertions.assertNull(deletedReally);
     }
 
+    
+    @Test
+    public void testClearKalturaId() throws Exception {
+        String id ="origin.test:id1";
+        String origin="origin.test";
+        String data = "Hello";
+        String parentId="origin.test:id_1_parent";
+        String referenceId="referenceId_123";
+        String referenceIdUpdated="referenceId_123_updated";
+        String kalturaId="kalturaId";
+        RecordTypeDto recordType=RecordTypeDto.MANIFESTATION;
+        
+        DsRecordDto record = new DsRecordDto();
+        record.setId(id);
+        record.setOrigin(origin);
+        record.setData(data);
+        record.setParentId(parentId);
+        record.setRecordType(RecordTypeDto.MANIFESTATION);
+        record.setReferenceId(referenceId);
+        record.setKalturaId(kalturaId);
+        storage.createNewRecord(record );
+        
+        //See referenceId and kalturaId is set correct
+        DsRecordDto newCreatedRecord=storage.loadRecord(id);
+        assertEquals(referenceId,newCreatedRecord.getReferenceId());
+        assertEquals(kalturaId,newCreatedRecord.getKalturaId());
+
+        //New update record, but the new record does not have kalturaId, but has a difference referenceId
+        record.setReferenceId(referenceIdUpdated);        
+        storage.updateRecord(record);        
+        DsRecordDto updatedRecord=storage.loadRecord(id);
+        //Test kalturaId is reset
+        assertNull(updatedRecord.getKalturaId());
+            
+    }
+    
     @Test
     public void testMappingCRUD() throws Exception {
         

--- a/src/test/java/dk/kb/storage/storage/DsStorageTest.java
+++ b/src/test/java/dk/kb/storage/storage/DsStorageTest.java
@@ -1,6 +1,7 @@
 package dk.kb.storage.storage;
 
 import dk.kb.storage.model.v1.DsRecordDto;
+import dk.kb.storage.model.v1.DsRecordReferenceIdDto;
 import dk.kb.storage.model.v1.MappingDto;
 import dk.kb.storage.model.v1.OriginCountDto;
 import dk.kb.storage.model.v1.RecordTypeDto;
@@ -156,7 +157,7 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         mappingDto1.setKalturaId(kalturaId1Updated);
         storage.updateMapping(mappingDto1);
         MappingDto map1Updated = storage.getMappingByReferenceId(id1); //load again
-        assertEquals(kalturaId1Updated,map1Updated.getKalturaId());                
+        assertEquals(kalturaId1Updated,map1Updated.getKalturaId());                        
         
     }
         
@@ -216,9 +217,9 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
     * |ID |REFERENCEID |KALTURAID
     * -------------------------------
     * |id1|referenceid1|     (null) |        (This can be enriched with kalturaid)
-    * |id1|referenceid2|     (null) |        (this record needs to be enriched, but referenceid2 is not in the mapping table) 
+    * |id2|referenceid2|     (null) |        (this record needs to be enriched, but referenceid2 is not in the mapping table) 
     * |id3|null        |     (null) |        (this record can not be enriched with kalturaid, no referenceId)
-    * |id4|referenceid4|(kalturaid4)|        (this  already has kalturaid)
+    * |id4|referenceid4| kalturaid4 |        (this  already has kalturaid)
     * 
     * MAPPING table:
     * |REFERENCEID | KALTURAID|
@@ -253,7 +254,33 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         
         //load record1 and see kalturaid is now set
         DsRecordDto recordAfter = storage.loadRecord(recordId);
-        assertEquals("kalturaid1",recordAfter.getKalturaId());        
+        assertEquals("kalturaid1",recordAfter.getKalturaId()); 
+        
+        
+        //batch over records and records are extract with correct values              
+        ArrayList<DsRecordReferenceIdDto> records = storage.getReferenceIds("test_origin1", 0, 10);
+        
+        //records order are id2,id3,id4,id1  (since id1 was modified it is last)
+        DsRecordReferenceIdDto id2 = records.get(0);        
+        assertEquals("id2",id2.getId());
+        assertEquals("referenceid2",id2.getReferenceId());
+        assertNull(id2.getKalturaId());
+        
+        DsRecordReferenceIdDto id3 = records.get(1);        
+        assertEquals("id3",id3.getId());
+        assertNull(id3.getReferenceId());
+        assertNull(id3.getKalturaId());
+        
+        DsRecordReferenceIdDto id4 = records.get(2);        
+        assertEquals("id4",id4.getId());
+        assertEquals("referenceid4",id4.getReferenceId());
+        assertEquals("kalturaid4",id4.getKalturaId());
+                
+        DsRecordReferenceIdDto id1 = records.get(3);        
+        assertEquals("id1",id1.getId());        
+        assertEquals("referenceid1",id1.getReferenceId());
+        assertEquals("kalturaid1",id1.getKalturaId());   
+        assertTrue(id1.getmTime()>0L);
     }
 
     @Test


### PR DESCRIPTION
Method that extract records after a given mTime. This is a much lighter version of that does not extract children,parents or the large data field. The fields are id,mTime,referenceId,KalturaId.
This will method will be called when enriching record (the mapping table) with kalturaIds.
