### PR TITLE
Dra 1134 continuationstream for record without data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Refactored endpoint record/referenceId to records/minimal 
+- Updated client with a ContinuationStream method calling the endpoint records/minimal
+- Deprecated the client method getDsRecordsReferenceIdModifiedAfter
+
 
 ## [2.0.0](https://github.com/kb-dk/ds-storage/releases/tag/ds-storage-2.0.0) 2024-07-01
 - Bumped version to fix x.y.z release format

--- a/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
+++ b/src/main/java/dk/kb/storage/api/v1/impl/DsStorageApiServiceImpl.java
@@ -4,7 +4,7 @@ import dk.kb.storage.api.v1.DsStorageApi;
 import dk.kb.storage.config.ServiceConfig;
 import dk.kb.storage.facade.DsStorageFacade;
 import dk.kb.storage.model.v1.DsRecordDto;
-import dk.kb.storage.model.v1.DsRecordReferenceIdDto;
+import dk.kb.storage.model.v1.DsRecordMinimalDto;
 import dk.kb.storage.model.v1.MappingDto;
 import dk.kb.storage.model.v1.OriginCountDto;
 import dk.kb.storage.model.v1.OriginDto;
@@ -333,9 +333,9 @@ public class DsStorageApiServiceImpl extends ImplBase implements DsStorageApi {
     * @return List of records only have fields id,mTime,referenceid and kalturaid
     */
     @Override
-    public List<DsRecordReferenceIdDto> referenceIds(String origin, Integer batchsize, Long mTime) {    
+    public List<DsRecordMinimalDto> referenceIds(String origin, Integer batchSize, Long mTime) {
         log.debug("referenceIds called with call details: {}", getCallDetails());
-        return DsStorageFacade.getReferenceIds(origin,mTime,batchsize);
+        return DsStorageFacade.getReferenceIds(origin,mTime,batchSize);
     }
     
 

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import dk.kb.storage.config.ServiceConfig;
 import dk.kb.storage.model.v1.DsRecordDto;
-import dk.kb.storage.model.v1.DsRecordReferenceIdDto;
+import dk.kb.storage.model.v1.DsRecordMinimalDto;
 import dk.kb.storage.model.v1.MappingDto;
 import dk.kb.storage.model.v1.OriginCountDto;
 import dk.kb.storage.model.v1.OriginDto;
@@ -46,12 +46,12 @@ public class DsStorageFacade {
      *
      * @return List of records only have fields id,mTime,referenceid and kalturaid
      */
-    public static  ArrayList<DsRecordReferenceIdDto>  getReferenceIds(String origin, long mTime, int batchSize)  {                       
+    public static  ArrayList<DsRecordMinimalDto>  getReferenceIds(String origin, long mTime, int batchSize)  {                       
         String id = String.format(Locale.ROOT, "getReferenceIds(origin='%s', mTime=%d, batchSize=%d)", origin, mTime, batchSize);
         return performStorageAction(id, storage -> {             
             return storage.getReferenceIds(origin, mTime, batchSize);   
         });
-    }    
+    }
     
 
     

--- a/src/main/java/dk/kb/storage/storage/DsStorage.java
+++ b/src/main/java/dk/kb/storage/storage/DsStorage.java
@@ -8,7 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import dk.kb.storage.model.v1.DsRecordDto;
-import dk.kb.storage.model.v1.DsRecordReferenceIdDto;
+import dk.kb.storage.model.v1.DsRecordMinimalDto;
 import dk.kb.storage.model.v1.MappingDto;
 import dk.kb.storage.model.v1.OriginCountDto;
 import dk.kb.storage.model.v1.RecordTypeDto;
@@ -395,12 +395,12 @@ public class DsStorage implements AutoCloseable {
      *
      * @return List of records only have fields id,mTime,referenceid and kalturaid
      */
-    public ArrayList<DsRecordReferenceIdDto> getReferenceIds(String origin, long mTime, int batchSize) throws SQLException {
+    public ArrayList<DsRecordMinimalDto> getReferenceIds(String origin, long mTime, int batchSize) throws SQLException {
 
         if (batchSize <1 || batchSize > 100000) { //No doom switch
             throw new InvalidArgumentServiceException("Batchsize must be in range 1 to 100000");          
         }
-        ArrayList<DsRecordReferenceIdDto> records = new ArrayList<DsRecordReferenceIdDto>();
+        ArrayList<DsRecordMinimalDto> records = new ArrayList<DsRecordMinimalDto>();
         try (PreparedStatement stmt = connection.prepareStatement(referenceIdsStatement)) {
 
             stmt.setString(1, origin);
@@ -409,7 +409,7 @@ public class DsStorage implements AutoCloseable {
                         
             try (ResultSet rs = stmt.executeQuery();) {
                 while (rs.next()) {
-                    DsRecordReferenceIdDto  record = createRecordReferenceIdFromRS(rs);
+                    DsRecordMinimalDto  record = createRecordReferenceIdFromRS(rs);
                     records.add(record);
                 }
             }
@@ -1075,13 +1075,13 @@ public class DsStorage implements AutoCloseable {
     }
 
     
-    private static DsRecordReferenceIdDto createRecordReferenceIdFromRS(ResultSet rs) throws SQLException {
+    private static DsRecordMinimalDto createRecordReferenceIdFromRS(ResultSet rs) throws SQLException {
         String id = rs.getString(ID_COLUMN);                              
         long mTime = rs.getLong(MTIME_COLUMN);
         String referenceId = rs.getString(RECORDS_REFERENCE_ID_COLUMN);
         String kalturaId = rs.getString(RECORDS_KALTURA_ID_COLUMN);
         
-        DsRecordReferenceIdDto record = new DsRecordReferenceIdDto();
+        DsRecordMinimalDto record = new DsRecordMinimalDto();
         record.setId(id);                        
         record.setmTime(mTime);        
         record.setReferenceId(referenceId);

--- a/src/main/java/dk/kb/storage/util/DsStorageClient.java
+++ b/src/main/java/dk/kb/storage/util/DsStorageClient.java
@@ -19,7 +19,7 @@ import dk.kb.storage.invoker.v1.ApiClient;
 import dk.kb.storage.invoker.v1.ApiException;
 import dk.kb.storage.invoker.v1.Configuration;
 import dk.kb.storage.model.v1.DsRecordDto;
-import dk.kb.storage.model.v1.DsRecordReferenceIdDto;
+import dk.kb.storage.model.v1.DsRecordMinimalDto;
 import dk.kb.storage.model.v1.MappingDto;
 import dk.kb.storage.model.v1.RecordTypeDto;
 import dk.kb.util.webservice.exception.InternalServiceException;
@@ -76,7 +76,7 @@ public class DsStorageClient extends DsStorageApi {
      * If the mapping already exist for the referenceid, the kalturaId value will be updated
      * </p>
      * 
-     * @param mappingDto The mapping entry to be create or updated
+     * @param mapping The mapping entry to be created or updated
      * 
      */
     public void updateMappings(MappingDto mapping) throws ApiException {               
@@ -97,7 +97,7 @@ public class DsStorageClient extends DsStorageApi {
      * @throws ApiException  
      * 
      */
-    public List<DsRecordReferenceIdDto> getDsRecordsReferenceIdModifiedAfter(String origin,int batchSize,long mTimeFrom) throws ApiException {        
+    public List<DsRecordMinimalDto> getDsRecordsReferenceIdModifiedAfter(String origin,int batchSize,long mTimeFrom) throws ApiException {        
        return super.referenceIds(origin, batchSize,mTimeFrom);                
     }
     

--- a/src/main/java/dk/kb/storage/util/DsStorageClient.java
+++ b/src/main/java/dk/kb/storage/util/DsStorageClient.java
@@ -98,7 +98,7 @@ public class DsStorageClient extends DsStorageApi {
      * 
      */
     public List<DsRecordMinimalDto> getDsRecordsReferenceIdModifiedAfter(String origin,int batchSize,long mTimeFrom) throws ApiException {        
-       return super.referenceIds(origin, batchSize,mTimeFrom);                
+       return super.getMinimalRecords(origin, batchSize,mTimeFrom);
     }
     
     

--- a/src/main/java/dk/kb/storage/util/DsStorageClient.java
+++ b/src/main/java/dk/kb/storage/util/DsStorageClient.java
@@ -82,12 +82,12 @@ public class DsStorageClient extends DsStorageApi {
     public void updateMappings(MappingDto mapping) throws ApiException {               
        super.mappingPost(mapping);                       
     }
-            
+
     /**
-     * <p>
+     * This method is deprecated. See: {@link #getDsRecordsMinimalModifiedAfterStream(String, int, long)}
      * Get a list of records having a referenceId after a given lastModified time
-     * Extract a list of records with a given batch size by origin and mTime larger than input. 
-     * The records will only has the id,mTime,referenceId and kalturaId fields set.         
+     * Extract a list of records with a given batch size by origin and mTime larger than input.
+     * The records will only have the id, mTime, referenceId and kalturaId fields set.
      * <p/>
      *  
      *  @param origin The Origin to extract records from
@@ -97,10 +97,10 @@ public class DsStorageClient extends DsStorageApi {
      * @throws ApiException  
      * 
      */
-    public List<DsRecordMinimalDto> getDsRecordsReferenceIdModifiedAfter(String origin,int batchSize,long mTimeFrom) throws ApiException {        
-       return super.getMinimalRecords(origin, batchSize,mTimeFrom);
+    @Deprecated
+    public List<DsRecordMinimalDto> getDsRecordsReferenceIdModifiedAfter(String origin,int batchSize,long mTimeFrom) throws ApiException {
+        return super.getMinimalRecords(origin, batchSize, mTimeFrom);
     }
-    
     
     /**
      * Call the remote ds-storage {@link #getRecordsModifiedAfter} and return the response in the form of a Stream 
@@ -210,6 +210,61 @@ public class DsStorageClient extends DsStorageApi {
                     "getRecordsModifiedAfterLocalTreeJSON(origin='%s', recordType='%s', mTime=%d, maxRecords=%d): " +
                             "Unable to construct URI",
                     origin, recordType, mTime, maxRecords);
+            log.warn(message, e);
+            throw new InternalServiceException(message);
+        }
+
+        log.debug("Opening streaming connection to '{}'", uri);
+        return ContinuationInputStream.from(uri, Long::valueOf);
+    }
+
+    /**
+     * Call the remote ds-storage {@link #getMinimalRecords(String, Integer, Long)} and return the response in the form of a Stream
+     * of records. Get a stream of minimal records having a referenceId after a given lastModified time. The records will only have the id, mTime, referenceId and kalturaId fields
+     * available.
+     * <p>
+     * The stream is unbounded by memory and gives access to the highest modification time (microseconds since
+     * Epoch 1970) for any record that will be delivered by the stream.
+     * <p>
+     * Important: Ensure that the returned stream is closed to avoid resource leaks.
+     * @param origin     the origin for the records.
+     * @param mTimeFrom      Exclusive start time for records to deliver:
+     *                   Epoch time in microseconds (milliseconds times 1000).
+     * @param maxRecords the maximum number of records to deliver. -1 means no limit.
+     * @return a stream of records from the remote ds-storage.
+     * @throws IOException if the connection to the remote ds-storage failed.
+     */
+    public ContinuationStream<DsRecordMinimalDto, Long> getDsRecordsMinimalModifiedAfterStream(String origin, int maxRecords, long mTimeFrom) throws IOException {
+        return getMinimalRecordsModifiedAfterJSON(origin, mTimeFrom, (long) maxRecords)
+                .stream(DsRecordMinimalDto.class);
+    }
+
+    /**
+     * Call the remote ds-storage {@link #getMinimalRecords} and return the JSON response unchanged as a wrapped bytestream.
+     * <p>
+     * Important: Ensure that the returned stream is closed to avoid resource leaks.
+     * @param origin     the origin for the records.
+     * @param mTime      exclusive start time for records to deliver:
+     *                   Epoch time in microseconds (milliseconds times 1000).
+     * @param maxRecords the maximum number of records to deliver. -1 means no limit.
+     * @return a raw bytestream with the response from the remote ds-storage.
+     * @throws IOException if the connection to the remote ds-storage failed.
+     */
+    public ContinuationInputStream<Long> getMinimalRecordsModifiedAfterJSON(String origin, Long mTime, Long maxRecords)
+            throws IOException {
+        URI uri;
+        try {
+            uri = new URIBuilder(serviceURI + "records/minimal")
+                    // setPath overwrites paths given in serviceURI
+                    // .setPath("records")
+                    .addParameter("origin", origin)
+                    .addParameter("mTime", Long.toString(mTime == null ? 0L : mTime))
+                    .addParameter("maxRecords", Long.toString(maxRecords == null ? 10 : maxRecords))
+                    .build();
+        } catch (URISyntaxException e) {
+            String message = String.format(Locale.ROOT,
+                    "getMinimalRecordsModifiedAfterJSON(origin='%s', mTime=%d, maxRecords=%d): Unable to construct URI",
+                    origin, mTime, maxRecords);
             log.warn(message, e);
             throw new InternalServiceException(message);
         }

--- a/src/main/openapi/ds-storage-openapi_v1.yaml
+++ b/src/main/openapi/ds-storage-openapi_v1.yaml
@@ -117,51 +117,6 @@ paths:
                 type: integer
                 format: int32
 
-
-  /record/referenceids:
-    get:
-      tags:
-        - '${project.name}'
-      summary: 'Get a list of records having a referenceId after a given lastModified time'
-      description: >
-       Extract a list of records with a given batch size by origin and mTime larger than input.        
-        The records will only has the id,mTime,referenceId and kalturaId fields set.       
-      operationId: referenceIds
-      parameters:
-        - name: origin
-          in: query
-          description: 'The origin to extract records for'
-          required: true
-          schema:
-            type: string
-            example: "ds.tv"
-        - name: mTime
-          in: query
-          description: 'Only extract records after this mTime.'
-          required: false
-          schema:
-            type: integer
-            format: int64
-            example: 1701262548465000
-            default: 0
-        - name: batchsize
-          in: query
-          description: 'Number of records to extract.'
-          required: true
-          schema:
-            type: integer            
-            example: 500
-            default: 500
-     
-      responses:
-        '200':
-          description: 'List of DsRecordReferenceId'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DsRecordMinimalList'
-
-
   /record/{id}:
     get:
       tags:
@@ -351,7 +306,50 @@ paths:
               schema:
                 $ref: '#/components/schemas/DsRecordList'
 
+  /records/minimal:
+    get:
+      tags:
+        - '${project.name}'
+      summary: 'Get a stream of minimal records having a referenceId after a given lastModified time'
+      description: >
+        Extract a list of records with a given batch size by origin and mTime larger than input.        
+         The records will only have the id, mTime, referenceId and kalturaId fields. This means that no actual data can be retrieved through this endpoint. It can however be used
+         for operations where the data from the record isn't needed. Such as updating Kaltura IDs for records, which is done with referenceId and kalturaId only.
+      operationId: getMinimalRecords
+      x-streamingOutput: true
+      parameters:
+        - name: origin
+          in: query
+          description: 'The origin to extract records for'
+          required: true
+          schema:
+            type: string
+            example: "ds.tv"
+        - name: mTime
+          in: query
+          description: 'Only extract records after this mTime.'
+          required: false
+          schema:
+            type: integer
+            format: int64
+            example: 1701262548465000
+            default: 0
+        - name: maxRecords
+          in: query
+          description: 'Number of records to extract.'
+          required: true
+          schema:
+            type: integer
+            example: 500
+            default: 500
 
+      responses:
+        '200':
+          description: 'List of DsRecordReferenceId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DsRecordMinimalList'
 
   /records/updateKalturaId:     
     post:

--- a/src/main/openapi/ds-storage-openapi_v1.yaml
+++ b/src/main/openapi/ds-storage-openapi_v1.yaml
@@ -159,7 +159,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DsRecordReferenceIdList'        
+                $ref: '#/components/schemas/DsRecordMinimalList'
 
 
   /record/{id}:
@@ -547,7 +547,7 @@ components:
           type: string
           description: 'The Kaltura  ID for the record. It can be null even if the record is Kaltura but the mapping has not been updated yet.  '
                                                         
-    DsRecordReferenceId:
+    DsRecordMinimal:
       type: object
       required:
         - id
@@ -588,10 +588,10 @@ components:
       items: 
         $ref: '#/components/schemas/DsRecord'
 
-    DsRecordReferenceIdList:
+    DsRecordMinimalList:
       type: array
       items: 
-        $ref: '#/components/schemas/DsRecordReferenceId'
+        $ref: '#/components/schemas/DsRecordMinimal'
 
 
 

--- a/src/test/java/dk/kb/storage/integration/DsStorageClientTest.java
+++ b/src/test/java/dk/kb/storage/integration/DsStorageClientTest.java
@@ -17,6 +17,7 @@ package dk.kb.storage.integration;
 import dk.kb.storage.config.ServiceConfig;
 import dk.kb.storage.invoker.v1.ApiException;
 import dk.kb.storage.model.v1.DsRecordDto;
+import dk.kb.storage.model.v1.DsRecordMinimalDto;
 import dk.kb.storage.model.v1.OriginCountDto;
 import dk.kb.storage.model.v1.RecordTypeDto;
 import dk.kb.storage.util.DsStorageClient;
@@ -210,6 +211,31 @@ public class DsStorageClientTest {
             System.out.println(records.getResponseHeaders());
             assertEquals(3L, count, "The requested number of records should be received");
             assertNotNull(records.getContinuationToken(),"The highest modification time should be present");
+        }
+    }
+
+    @Test
+    public void testRemoteMinimalRecordsStream() throws IOException {
+        try (ContinuationStream<DsRecordMinimalDto, Long> records = remote.getDsRecordsMinimalModifiedAfterStream(
+                "ds.tv", 5, 0L)){
+            long count = records.count();
+
+            assertEquals(5L, count, "The requested number of records should be received");
+            assertNotNull(records.getContinuationToken(),"The highest modification time should be present");
+
+        }
+
+    }
+
+    @Test
+    public void testRemoteMinimalRecordsContent() throws IOException {
+        try (ContinuationInputStream recordsIS = remote.getMinimalRecordsModifiedAfterJSON(
+                "ds.tv", 0L, 10L)) {
+            String recordsStr = IOUtils.toString(recordsIS, StandardCharsets.UTF_8);
+            assertTrue(recordsStr.contains("\"id\":\"ds.tv:oai"),
+                    "At least 1 JSON block for a record should be returned");
+            // Minimal records shouldn't contain data
+            assertFalse(recordsStr.contains("\"data\":"));
         }
     }
 

--- a/src/test/java/dk/kb/storage/storage/DsStorageTest.java
+++ b/src/test/java/dk/kb/storage/storage/DsStorageTest.java
@@ -1,7 +1,7 @@
 package dk.kb.storage.storage;
 
 import dk.kb.storage.model.v1.DsRecordDto;
-import dk.kb.storage.model.v1.DsRecordReferenceIdDto;
+import dk.kb.storage.model.v1.DsRecordMinimalDto;
 import dk.kb.storage.model.v1.MappingDto;
 import dk.kb.storage.model.v1.OriginCountDto;
 import dk.kb.storage.model.v1.RecordTypeDto;
@@ -258,25 +258,25 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         
         
         //batch over records and records are extract with correct values              
-        ArrayList<DsRecordReferenceIdDto> records = storage.getReferenceIds("test_origin1", 0, 10);
+        ArrayList<DsRecordMinimalDto> records = storage.getReferenceIds("test_origin1", 0, 10);
         
         //records order are id2,id3,id4,id1  (since id1 was modified it is last)
-        DsRecordReferenceIdDto id2 = records.get(0);        
+        DsRecordMinimalDto id2 = records.get(0);        
         assertEquals("id2",id2.getId());
         assertEquals("referenceid2",id2.getReferenceId());
         assertNull(id2.getKalturaId());
         
-        DsRecordReferenceIdDto id3 = records.get(1);        
+        DsRecordMinimalDto id3 = records.get(1);        
         assertEquals("id3",id3.getId());
         assertNull(id3.getReferenceId());
         assertNull(id3.getKalturaId());
         
-        DsRecordReferenceIdDto id4 = records.get(2);        
+        DsRecordMinimalDto id4 = records.get(2);        
         assertEquals("id4",id4.getId());
         assertEquals("referenceid4",id4.getReferenceId());
         assertEquals("kalturaid4",id4.getKalturaId());
                 
-        DsRecordReferenceIdDto id1 = records.get(3);        
+        DsRecordMinimalDto id1 = records.get(3);        
         assertEquals("id1",id1.getId());        
         assertEquals("referenceid1",id1.getReferenceId());
         assertEquals("kalturaid1",id1.getKalturaId());   


### PR DESCRIPTION
Wrapping your work returning a list of reference ID records in ContinuationStreams so that the miniaml record method can be called nicely through the client. 

Also made some slight refactoring of the endpoint names. If you agree I will fix use-cases in ds-datahandler afterwards, when i change the enrichment endpoint to use this method. This branch is currently deployed to devel.