### PR TITLE
Fixed importing dependencies from multiple locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Property for database connection pool size. Under 'db' property new property: 'connectionPoolSize'. Reasonable values are from 10 to 100. 
 
+### Fixed
+- Fixed inclusion of the same dependencies from multiple sources.
+
 ## [2.3.2](https://github.com/kb-dk/ds-storage/releases/tag/ds-storage-2.3.2) 2025-01-07
 ### Changed
 - Upgraded dependency cxf-rt-transports-http to v.3.6.4 (fix memory leak)

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>dk.kb.util</groupId>
             <artifactId>kb-util</artifactId>
-            <version>1.5.11</version>
+            <version>1.6.2</version>
             <exclusions>
                 <exclusion>
                     <!-- kb-util has 2.3.3, but transitive resolving has 2.4.0 somewhere-->
@@ -149,6 +149,18 @@
             <groupId>javax.xml.ws</groupId>
             <artifactId>jaxws-api</artifactId>
             <version>2.3.1</version>
+            <exclusions>
+                <!-- Project has jakarta.xml.bind-api v. 2.3.3 from cxf-rt-transports-http-->
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+                <!-- Project has jakarta.annotation-api v.1.3.5 through KB-util dependency.-->
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -319,6 +331,18 @@
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-junit-jupiter</artifactId>
             <version>5.15.0</version>
+            <exclusions>
+                <!-- Project has it through jetty-servlet-api v.4.0.6 somewhere. -->
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+                <!-- Project has istack-commons-runtime-3.0.12 from KB util dependency -->
+                <exclusion>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider -->


### PR DESCRIPTION
Deployed to devel server. I've tested all get endpoints locally. 

This reduces amounts of warnings when starting the service with jetty from approx. 600 to 4. The last warning from `org.apache.commons.logging` i cant seem to exclude correctly....