### PR TITLE
Dra 2062 Unittest methods moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Changed
+- Moved storage method that is only used by unit tests to a storage subclass used by unittest. The methods are very destructive such as clearing all tables.
 
 ## [3.0.0](https://github.com/kb-dk/ds-storage/releases/tag/ds-storage-3.0.0) 2025-06-12
 ### Added

--- a/src/main/java/dk/kb/storage/storage/DsStorage.java
+++ b/src/main/java/dk/kb/storage/storage/DsStorage.java
@@ -56,10 +56,6 @@ public class DsStorage implements AutoCloseable {
     private static final String MAPPING_REFERENCE_ID_COLUMN = "referenceid";
     private static final String MAPPING_KALTURA_ID_COLUMN = "kalturaid";
 
-    private static String clearTableRecordsStatement = "DELETE FROM " + RECORDS_TABLE;
-    private static String clearTableMappingsStatement = "DELETE FROM " + MAPPING_TABLE;
-    
-
     private static String createRecordStatement = "INSERT INTO " + RECORDS_TABLE +
             " (" + ID_COLUMN + ", " + ORIGIN_COLUMN + ", " +ORGID_COLUMN + ","+ RECORDTYPE_COLUMN +"," + IDERROR_COLUMN +","+ DELETED_COLUMN + ", " + CTIME_COLUMN + ", " + MTIME_COLUMN + ", " + DATA_COLUMN + ", " + PARENT_ID_COLUMN +  " , " + RECORDS_REFERENCE_ID_COLUMN +" , "+RECORDS_KALTURA_ID_COLUMN+")"+
             " VALUES (?,?,?,?,?,?,?,?,?,?,?,?)";
@@ -236,7 +232,7 @@ public class DsStorage implements AutoCloseable {
     // statistics shown on monitor.jsp page
     public static Date INITDATE = null;
 
-    private Connection connection;
+    protected Connection connection;
 
     public static void initialize(String driverName, String driverUrl, String userName, String password) {
         
@@ -346,19 +342,6 @@ public class DsStorage implements AutoCloseable {
     }
 
 
-    /*
-     * Only called from unittests, not exposed on facade class
-     * Will remove all entries in the record of mapping table
-     * 
-     */
-    public void clearMappingAndRecordTable() throws SQLException {
-        try (PreparedStatement stmt = connection.prepareStatement(clearTableRecordsStatement)) {
-            stmt.execute(); //No result set to close
-        }        
-        try (PreparedStatement stmt = connection.prepareStatement(clearTableMappingsStatement)) {
-            stmt.execute(); //No result set to close
-        }
-    }
 
     /**
      * Will only extract with records strictly larger than mTime!

--- a/src/test/java/dk/kb/storage/storage/DsStorageForUnitTest.java
+++ b/src/test/java/dk/kb/storage/storage/DsStorageForUnitTest.java
@@ -1,0 +1,47 @@
+package dk.kb.storage.storage;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>
+ * This class is a small extension of the DsStorage with a few methods used for unittest 
+ * that we do not want in the production code.
+ *
+ * <p>
+ * Between each unittest the all tables are cleared for data and the method is only defined in this subclass  
+ */
+public class DsStorageForUnitTest extends DsStorage  {
+
+    private static final Logger log = LoggerFactory.getLogger(DsStorageForUnitTest.class);
+
+    private static String clearTableRecordsStatement = "DELETE FROM DS_RECORDS";
+    private static String clearTableMappingsStatement = "DELETE FROM DS_MAPPING";
+    
+
+    
+    public  DsStorageForUnitTest() throws SQLException {
+        super();
+    }
+   
+
+    /** 
+     * Will clear data in ds_records and ds_mapping tables. Unit test functionality only. 
+     * 
+     */
+    public void clearMappingAndRecordTable() throws SQLException {
+        try (PreparedStatement stmt = connection.prepareStatement(clearTableRecordsStatement)) {
+            stmt.execute(); //No result set to close
+        }        
+        try (PreparedStatement stmt = connection.prepareStatement(clearTableMappingsStatement)) {
+            stmt.execute(); //No result set to close
+        }
+        
+        connection.commit();
+        log.info("Tables cleared for unittest");
+    }
+
+}

--- a/src/test/java/dk/kb/storage/storage/DsStorageUnitTestUtil.java
+++ b/src/test/java/dk/kb/storage/storage/DsStorageUnitTestUtil.java
@@ -32,7 +32,7 @@ public abstract class DsStorageUnitTestUtil {
     protected static final String USERNAME = "";
     protected static final String PASSWORD = "";
 
-    protected static DsStorage storage = null;
+    protected static DsStorageForUnitTest storage = null;
 
     private static final Logger log = LoggerFactory.getLogger(DsStorageUnitTestUtil.class);
 
@@ -43,7 +43,7 @@ public abstract class DsStorageUnitTestUtil {
         ServiceConfig.initialize("conf/ds-storage*.yaml"); 	    
         H2DbUtil.createEmptyH2DBFromDDL(URL,DRIVER,USERNAME,PASSWORD);
         DsStorage.initialize(DRIVER, URL, USERNAME, PASSWORD);
-        storage = new DsStorage();
+        storage = new DsStorageForUnitTest();
 
 
     }


### PR DESCRIPTION
 Moved storage method that is only used by unit tests to a storage subclass used by unittest. 