### PR TITLE
fixed that different records have same file reference due to data errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Fix multiple records have same stream defined.This should not happen but it does due to data errors.
 
 ## [3.0.1](https://github.com/kb-dk/ds-storage/releases/tag/ds-storage-3.0.1) 2025-09-01
 ### Changed

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -167,13 +167,14 @@ public class DsStorageFacade {
     
     /**
      * Update kaltura id for a record. The kaltura id is given to the record when uploaded to Kaltura. The Kaltura id must then later be updated with this method.
-     * 
+     * Due to data error there can be several records having same stream.
+     *  
      * @param referenceId The referenceId given to the record when uploaded to Kaltura
      * @param kalturaId The Kaltura id in the kaltura system. The id is given to a record after upload.
      */
     public static void updateKalturaIdForRecord(String referenceId, String kalturaId){
          performStorageAction("updateKalturaIdForRecord(" + referenceId + ")", storage -> {
-         storage.updateKalturaIdForRecord(referenceId, kalturaId);         
+         storage.updateKalturaIdForRecords(referenceId, kalturaId);         
         return null;    // Something must be returned
         });
     }

--- a/src/main/java/dk/kb/storage/storage/DsStorage.java
+++ b/src/main/java/dk/kb/storage/storage/DsStorage.java
@@ -1040,18 +1040,17 @@ public class DsStorage implements AutoCloseable {
         
         long nowStamp = UniqueTimestampGenerator.next();      
         for (String id:recordIds) {        
-        try (PreparedStatement stmt = connection.prepareStatement(updateKalturaIdStatement)) {
-            stmt.setString(1, kalturaId);
-            stmt.setLong(2, nowStamp);
-            stmt.setString(3, id);  
-            int updated = stmt.executeUpdate();            
-        } catch (SQLException e) {
-            String message = "SQL Exception in updateKalturaId for referenceId:" + referenceId + " error:" + e.getMessage();
-            log.error(message);
-            throw new SQLException(message, e);
-        }
-       }
-        
+          try (PreparedStatement stmt = connection.prepareStatement(updateKalturaIdStatement)) {
+              stmt.setString(1, kalturaId);
+              stmt.setLong(2, nowStamp);
+              stmt.setString(3, id);  
+              int updated = stmt.executeUpdate();            
+          } catch (SQLException e) {
+              String message = "SQL Exception in updateKalturaId for referenceId:" + referenceId + " error:" + e.getMessage();
+              log.error(message);
+              throw new SQLException(message, e);
+           }
+       }        
     }
     
     public void updateReferenceIdForRecord(String recordId, String referenceId) throws Exception {

--- a/src/main/java/dk/kb/storage/storage/DsStorage.java
+++ b/src/main/java/dk/kb/storage/storage/DsStorage.java
@@ -92,7 +92,7 @@ public class DsStorage implements AutoCloseable {
             ID_COLUMN+ "= ?";
     
 
-    private static String getRecordsByKalturaId = "SELECT "+ID_COLUMN+ " FROM " +RECORDS_TABLE  + " WHERE "+ RECORDS_REFERENCE_ID_COLUMN+" = ?";    
+    private static String getRecordsByReferenceId = "SELECT "+ID_COLUMN+ " FROM " +RECORDS_TABLE  + " WHERE "+ RECORDS_REFERENCE_ID_COLUMN+" = ?";    
 
     private static String updateReferenceIdStatement = "UPDATE " + RECORDS_TABLE + " SET  "+ 
             RECORDS_REFERENCE_ID_COLUMN + " = ? ,"+
@@ -352,17 +352,17 @@ public class DsStorage implements AutoCloseable {
      * @throws SQLException
      */
     public ArrayList<String> getIdsByReferenceId(String referenceid) throws SQLException {
-        ArrayList<String> childIds = new ArrayList<>();
-        try (PreparedStatement stmt = connection.prepareStatement(getRecordsByKalturaId)) {
+        ArrayList<String> ids = new ArrayList<>();
+        try (PreparedStatement stmt = connection.prepareStatement(getRecordsByReferenceId)) {
             stmt.setString(1, referenceid);
             try (ResultSet rs = stmt.executeQuery()) {
                 while (rs.next()) {
                     String id = rs.getString(ID_COLUMN);
-                    childIds.add(id);
+                    ids.add(id);
                 }
             }
         }
-        return childIds;
+        return ids;
     }
     
     /**

--- a/src/test/java/dk/kb/storage/storage/DsStorageTest.java
+++ b/src/test/java/dk/kb/storage/storage/DsStorageTest.java
@@ -180,7 +180,7 @@ public class DsStorageTest extends DsStorageUnitTestUtil{
         storage.createNewRecord(record );
         
         //Update kaltura Id.
-        storage.updateKalturaIdForRecord(kalturaReferenceId, kalturaId);
+        storage.updateKalturaIdForRecords(kalturaReferenceId, kalturaId);
      
         //Load and test kalturaId correct
         DsRecordDto recordUpdated = storage.loadRecord(recordId);


### PR DESCRIPTION
Fixed that different records share same stream (file_reference). This should not happen but it does.
Dirty data or test data errors.