### PR TITLE
Fix keep kaltura if updated record has same reference_id (file)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed all logic using intermediate Kaltura Mapping table. Not used any longer.
 - Table can be deleted with: DROP TABLE DS_MAPPING;
 
+### Fixed
+- Fixed keeping kalturaID in table when updating a record, if referenceID is the same for new and old record.
+
 ## [4.0.0](https://github.com/kb-dk/ds-storage/releases/tag/ds-storage-4.0.0) - 2026-01-29
 
 ### Added

--- a/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
+++ b/src/main/java/dk/kb/storage/facade/DsStorageFacade.java
@@ -138,10 +138,14 @@ public class DsStorageFacade {
                 DsRecordDto oldRecord = storage.loadRecord(record.getId());
               
                 //Keep old kalturaId if referenceid is the same.
-                 if (record.getKalturaId() == null && record.getReferenceId() != null && !record.getReferenceId().equals(oldRecord.getReferenceId())) {                   
+                if (record.getKalturaId() == null && record.getReferenceId() != null  && record.getReferenceId().equals(oldRecord.getReferenceId()) ) {                   
                     record.setKalturaId(oldRecord.getKalturaId());                      
-                 }                                
-                log.info("Updating record with id: '{}'", record.getId());
+                   log.info("Updating record with id: '{}' Keeping kalturaID: '{}'", record.getId() , oldRecord.getKalturaId());
+                }
+                else {                
+                   log.info("Updating record with id: '{}' Clearing kalturaID since referenceID has changed '{}' to  '{}'", record.getId() ,oldRecord.getReferenceId(),record.getReferenceId() );
+                    record.setKalturaId(null);
+                }                
                 storage.updateRecord(record);
             } else {               
                 log.info("Creating new record with id: '{}'", record.getId());

--- a/src/test/java/dk/kb/storage/facade/DsStorageFacadeTest.java
+++ b/src/test/java/dk/kb/storage/facade/DsStorageFacadeTest.java
@@ -42,6 +42,7 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
     
     
     
+
     @Test
     public void testCreateAndUpdate() {
         //TODO describe flow below
@@ -59,12 +60,16 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
         String origin="doms.radio"; //Must be defined in yaml properties as allowed origin
         String data = "Hello";
         String parentId="doms.radio:id_1_parent";
-
+        String file_ref="1234";
+        String kalturaID="kalturaId1";
+        
         DsRecordDto record = new DsRecordDto();
         record.setId(id);
         record.setOrigin(origin);
         record.setData(data);
         record.setParentId(parentId);
+        record.setKalturaId(kalturaID);
+        record.setReferenceId(file_ref);
         record.setRecordType(RecordTypeDto.MANIFESTATION);
         DsStorageFacade.createOrUpdateRecord(record );
 
@@ -84,22 +89,30 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
         String dataUpdate = "Hello updated";
         String parentIdUpdated="doms.radio:id_2_parent";
         long cTimeBefore = recordLoaded.getcTime(); //Must be the same
-
+        record.setKalturaId(null); //This must be set correct automatic
+        record.setReferenceId(file_ref);        
         record.setData(dataUpdate);
         record.setParentId(parentIdUpdated);            
 
         DsStorageFacade.createOrUpdateRecord(record);
 
-        //Check new updated record is correct.
+        //Check new updated record is correct and kalturaID kept
         DsRecordDto recordUpdated = DsStorageFacade.getRecord(id,false);
         assertEquals(id,recordUpdated.getId());
         assertEquals(origin,recordUpdated .getOrigin());
         assertEquals(parentIdUpdated,record.getParentId());        
         assertTrue(recordUpdated.getmTime() >recordUpdated.getcTime() ); //Modified is now newer
         assertEquals(cTimeBefore, recordUpdated.getcTime());  //Created time is not changed on update
-
-
+        assertEquals(kalturaID, recordUpdated.getKalturaId()); //KalturaId is kept
+        
+        //test kalturaID is blanked.
+        record.setReferenceId("new_ref"); //this is a new file so kaltura should be blanked
+        DsStorageFacade.createOrUpdateRecord(record);
+        recordUpdated = DsStorageFacade.getRecord(id,false);
+        assertNull(recordUpdated.getKalturaId());        
+        
     }
+
 
     
     @Test
@@ -126,12 +139,12 @@ public class DsStorageFacadeTest extends DsStorageUnitTestUtil{
         assertEquals(referenceId,newCreatedRecord.getReferenceId());
         assertEquals(kalturaId,newCreatedRecord.getKalturaId());
 
-        //New update record, but the new record does not have kalturaId, but has a difference referenceId
+        //New update record, but the new record does not have kalturaId, but has a difference referenceId. Kalturaid must be blanked
         record.setReferenceId(referenceIdUpdated);        
-        record.setKalturaId(null); //blank, but updated post will still have old value
+        record.setKalturaId(null); //blank,
         DsStorageFacade.createOrUpdateRecord(record);        
         DsRecordDto updatedRecord=DsStorageFacade.getRecordTree(id);
-        assertEquals(kalturaId,updatedRecord.getKalturaId());            
+        assertNull(updatedRecord.getKalturaId());            
     }
     
     @Test


### PR DESCRIPTION
Keep kalturaid if reference ID is not changed when updating a record. 


Has been tested on devel and seen kaltura_id is not cleared.