### PR TITLE
DRA-2708-minimum-client-jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Removed all logic using intermediate Kaltura Mapping table. Not used any longer.
 - Table can be deleted with: DROP TABLE DS_MAPPING;
+- Create minimum client jar. Cross module dependencies uses this new jar instead of the full classes jar.
 
 ### Fixed
 - Fixed keeping kalturaID in table when updating a record, if referenceID is the same for new and old record.

--- a/pom.xml
+++ b/pom.xml
@@ -432,6 +432,7 @@
                     </excludes>
                 </configuration>
             </plugin>
+            
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
@@ -443,8 +444,8 @@
                         </manifest>
                     </archive>
 
-                    <!-- Generate a JAR with client classes and openapi-YAML for easy use by other services -->
-                    <attachClasses>true</attachClasses>
+                   <!-- Generation of API jar is done seperate plugin and only contains DTOs and client class -->                    
+                   <!-- <attachClasses>true</attachClasses> --> 
 
                     <!--Enable maven filtering for the web.xml-->
                     <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
@@ -469,8 +470,26 @@
                 </configuration>
             </plugin>
 
-
-
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-jar-plugin</artifactId>            
+               <executions>
+                   <execution>
+                   <id>build-specific-jar</id>
+                   <phase>package</phase>
+                   <goals>
+                       <goal>jar</goal>
+                   </goals>
+                  <configuration>                
+                      <classifier>api</classifier>
+                      <includes>                       
+                          <include>dk/kb/storage/model/**</include>
+                          <include>dk/kb/storage/util/DsStorageClient*</include>                                            
+                      </includes>
+                 </configuration>
+                 </execution>
+              </executions>
+            </plugin>
 
             <!-- Used only for mvn jetty:run jetty:run-war -->
             <plugin>


### PR DESCRIPTION
Build new minimum client-jar with DTO's and client class only. Use maven jar plugin. New classifier is 'api'.
Remove building old jar for all classes. Cross module dependencies use the new minimum api jar.